### PR TITLE
feat: TV shows CRUD forms (#6)

### DIFF
--- a/src/components/Credenza.tsx
+++ b/src/components/Credenza.tsx
@@ -1,0 +1,108 @@
+import * as React from "react";
+
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "#/components/ui/dialog";
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "#/components/ui/sheet";
+
+function useIsDesktop() {
+  const [isDesktop, setIsDesktop] = React.useState(false);
+
+  React.useEffect(() => {
+    const mediaQuery = window.matchMedia("(min-width: 768px)");
+    const updateMatches = () => setIsDesktop(mediaQuery.matches);
+
+    updateMatches();
+    mediaQuery.addEventListener("change", updateMatches);
+
+    return () => mediaQuery.removeEventListener("change", updateMatches);
+  }, []);
+
+  return isDesktop;
+}
+
+function Credenza({ children, ...props }: React.ComponentProps<typeof Dialog>) {
+  const isDesktop = useIsDesktop();
+  const Root = isDesktop ? Dialog : Sheet;
+
+  return <Root {...props}>{children}</Root>;
+}
+
+function CredenzaTrigger({ children, ...props }: React.ComponentProps<typeof DialogTrigger>) {
+  const isDesktop = useIsDesktop();
+  const Trigger = isDesktop ? DialogTrigger : SheetTrigger;
+
+  return <Trigger {...props}>{children}</Trigger>;
+}
+
+function CredenzaClose({ children, ...props }: React.ComponentProps<typeof DialogClose>) {
+  const isDesktop = useIsDesktop();
+  const Close = isDesktop ? DialogClose : SheetClose;
+
+  return <Close {...props}>{children}</Close>;
+}
+
+function CredenzaContent({ children, ...props }: React.ComponentProps<typeof DialogContent>) {
+  const isDesktop = useIsDesktop();
+  const Content = isDesktop ? DialogContent : SheetContent;
+
+  return <Content {...props}>{children}</Content>;
+}
+
+function CredenzaHeader({ children, ...props }: React.ComponentProps<"div">) {
+  const isDesktop = useIsDesktop();
+  const Header = isDesktop ? DialogHeader : SheetHeader;
+
+  return <Header {...props}>{children}</Header>;
+}
+
+function CredenzaFooter({ children, ...props }: React.ComponentProps<"div">) {
+  const isDesktop = useIsDesktop();
+  const Footer = isDesktop ? DialogFooter : SheetFooter;
+
+  return <Footer {...props}>{children}</Footer>;
+}
+
+function CredenzaTitle({ children, ...props }: React.ComponentProps<typeof DialogTitle>) {
+  const isDesktop = useIsDesktop();
+  const Title = isDesktop ? DialogTitle : SheetTitle;
+
+  return <Title {...props}>{children}</Title>;
+}
+
+function CredenzaDescription({
+  children,
+  ...props
+}: React.ComponentProps<typeof DialogDescription>) {
+  const isDesktop = useIsDesktop();
+  const Description = isDesktop ? DialogDescription : SheetDescription;
+
+  return <Description {...props}>{children}</Description>;
+}
+
+export {
+  Credenza,
+  CredenzaClose,
+  CredenzaContent,
+  CredenzaDescription,
+  CredenzaFooter,
+  CredenzaHeader,
+  CredenzaTitle,
+  CredenzaTrigger,
+};

--- a/src/components/DeleteShowDialog.tsx
+++ b/src/components/DeleteShowDialog.tsx
@@ -1,0 +1,66 @@
+import { toast } from "sonner";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "#/components/ui/alert-dialog";
+import { useDeleteShow } from "#/hooks/useShows";
+import { getApiErrorMessage } from "#/lib/api-errors";
+import type { TvShow } from "#/types/tvShow";
+
+interface DeleteShowDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  show: TvShow | null;
+}
+
+export function DeleteShowDialog({ open, onOpenChange, show }: DeleteShowDialogProps) {
+  const deleteShow = useDeleteShow();
+
+  async function handleDelete() {
+    if (!show) {
+      return;
+    }
+
+    try {
+      await deleteShow.mutateAsync(show);
+      toast.success(`"${show.title}" was removed from the catalogue.`);
+      onOpenChange(false);
+    } catch (error) {
+      const message = getApiErrorMessage(error, "Could not delete the TV show.");
+
+      toast.error(
+        message.includes("another asset holds a reference")
+          ? "This show is still referenced by another record. Remove its related seasons or watchlist entries first."
+          : message,
+      );
+    }
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete show?</AlertDialogTitle>
+          <AlertDialogDescription>
+            {show
+              ? `This will permanently remove "${show.title}" from the catalogue. This action cannot be undone.`
+              : "This will permanently remove the selected TV show from the catalogue."}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={deleteShow.isPending}>Cancel</AlertDialogCancel>
+          <AlertDialogAction disabled={deleteShow.isPending} onClick={handleDelete}>
+            {deleteShow.isPending ? "Deleting..." : "Delete Show"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/ShowCard.tsx
+++ b/src/components/ShowCard.tsx
@@ -4,6 +4,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { Button } from "#/components/ui/button";
 import { Card, CardContent } from "#/components/ui/card";
 import {
+  DropdownMenuGroup,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -13,9 +14,11 @@ import type { TvShow } from "#/types/tvShow";
 
 interface ShowCardProps {
   show: TvShow;
+  onEdit: (show: TvShow) => void;
+  onDelete: (show: TvShow) => void;
 }
 
-export function ShowCard({ show }: ShowCardProps) {
+export function ShowCard({ show, onEdit, onDelete }: ShowCardProps) {
   const showId = encodeURIComponent(show.title);
 
   return (
@@ -34,7 +37,7 @@ export function ShowCard({ show }: ShowCardProps) {
             <Button
               variant="secondary"
               size="icon"
-              className="h-7 w-7 opacity-0 transition-opacity group-hover:opacity-100"
+              className="h-7 w-7 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100"
               onClick={e => e.preventDefault()}
             >
               <HugeiconsIcon icon={MoreHorizontalIcon} size={16} />
@@ -42,10 +45,12 @@ export function ShowCard({ show }: ShowCardProps) {
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            <DropdownMenuItem disabled>Edit</DropdownMenuItem>
-            <DropdownMenuItem disabled className="text-destructive focus:text-destructive">
-              Delete
-            </DropdownMenuItem>
+            <DropdownMenuGroup>
+              <DropdownMenuItem onSelect={() => onEdit(show)}>Edit</DropdownMenuItem>
+              <DropdownMenuItem variant="destructive" onSelect={() => onDelete(show)}>
+                Delete
+              </DropdownMenuItem>
+            </DropdownMenuGroup>
           </DropdownMenuContent>
         </DropdownMenu>
       </div>

--- a/src/components/ShowFormDialog.tsx
+++ b/src/components/ShowFormDialog.tsx
@@ -1,0 +1,175 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+
+import {
+  Credenza,
+  CredenzaContent,
+  CredenzaDescription,
+  CredenzaFooter,
+  CredenzaHeader,
+  CredenzaTitle,
+} from "#/components/Credenza";
+import { Button } from "#/components/ui/button";
+import { Input } from "#/components/ui/input";
+import { Label } from "#/components/ui/label";
+import { Textarea } from "#/components/ui/textarea";
+import { useCreateShow, useUpdateShow } from "#/hooks/useShows";
+import { getApiErrorMessage } from "#/lib/api-errors";
+import { createTvShowSchema, type TvShowFormValues } from "#/schemas/tvShow";
+import type { TvShow } from "#/types/tvShow";
+
+interface ShowFormDialogProps {
+  existingShows: TvShow[];
+  mode: "create" | "edit";
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  show?: TvShow | null;
+}
+
+export function ShowFormDialog({
+  existingShows,
+  mode,
+  open,
+  onOpenChange,
+  show,
+}: ShowFormDialogProps) {
+  const createShow = useCreateShow();
+  const updateShow = useUpdateShow();
+  const currentTitle = mode === "edit" ? show?.title : undefined;
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<TvShowFormValues>({
+    resolver: zodResolver(createTvShowSchema(existingShows, currentTitle)),
+    defaultValues: {
+      title: show?.title ?? "",
+      description: show?.description ?? "",
+      recommendedAge: show?.recommendedAge ?? 16,
+    },
+  });
+
+  useEffect(() => {
+    reset({
+      title: show?.title ?? "",
+      description: show?.description ?? "",
+      recommendedAge: show?.recommendedAge ?? 16,
+    });
+  }, [open, reset, show]);
+
+  async function onSubmit(values: TvShowFormValues) {
+    try {
+      if (mode === "create") {
+        await createShow.mutateAsync(values);
+        toast.success(`"${values.title}" was created successfully.`);
+      } else if (show) {
+        await updateShow.mutateAsync({
+          current: show,
+          next: {
+            title: values.title,
+            description: values.description,
+            recommendedAge: values.recommendedAge,
+          },
+        });
+        toast.success(`"${values.title}" was updated successfully.`);
+      }
+
+      onOpenChange(false);
+      reset({
+        title: values.title,
+        description: values.description,
+        recommendedAge: values.recommendedAge,
+      });
+    } catch (error) {
+      toast.error(
+        getApiErrorMessage(
+          error,
+          mode === "create" ? "Could not create the TV show." : "Could not update the TV show.",
+        ),
+      );
+    }
+  }
+
+  const isPending = createShow.isPending || updateShow.isPending;
+  const title = mode === "create" ? "New Show" : "Edit Show";
+  const description =
+    mode === "create"
+      ? "Add a new title to your catalogue with a clear name and description."
+      : "Update the current show details without leaving the browse page.";
+  const actionLabel = mode === "create" ? "Create Show" : "Save Changes";
+
+  return (
+    <Credenza open={open} onOpenChange={onOpenChange}>
+      <CredenzaContent>
+        <CredenzaHeader>
+          <CredenzaTitle>{title}</CredenzaTitle>
+          <CredenzaDescription>{description}</CredenzaDescription>
+        </CredenzaHeader>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-5" noValidate>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="show-title">Title</Label>
+            <Input
+              id="show-title"
+              aria-invalid={Boolean(errors.title)}
+              placeholder="Breaking Bad"
+              readOnly={mode === "edit"}
+              className={mode === "edit" ? "bg-muted/60 text-muted-foreground" : undefined}
+              {...register("title")}
+            />
+            {errors.title ? (
+              <p className="text-sm text-destructive">{errors.title.message}</p>
+            ) : null}
+            {mode === "edit" ? (
+              <p className="text-sm text-muted-foreground">
+                Title changes are locked because other records may reference this show by title.
+              </p>
+            ) : null}
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="show-description">Description</Label>
+            <Textarea
+              id="show-description"
+              aria-invalid={Boolean(errors.description)}
+              placeholder="A gripping summary that helps you recognize the show later."
+              {...register("description")}
+            />
+            {errors.description ? (
+              <p className="text-sm text-destructive">{errors.description.message}</p>
+            ) : null}
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="show-recommended-age">Recommended age</Label>
+            <Input
+              id="show-recommended-age"
+              type="number"
+              min={0}
+              step={1}
+              aria-invalid={Boolean(errors.recommendedAge)}
+              placeholder="16"
+              {...register("recommendedAge", { valueAsNumber: true })}
+            />
+            {errors.recommendedAge ? (
+              <p className="text-sm text-destructive">{errors.recommendedAge.message}</p>
+            ) : null}
+          </div>
+
+          <CredenzaFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isPending}>
+              {isPending ? "Saving..." : actionLabel}
+            </Button>
+          </CredenzaFooter>
+        </form>
+      </CredenzaContent>
+    </Credenza>
+  );
+}

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,130 @@
+import * as React from "react";
+import { AlertDialog as AlertDialogPrimitive } from "radix-ui";
+
+import { cn } from "#/lib/utils";
+import { buttonVariants } from "#/components/ui/button";
+
+function AlertDialog({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />;
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />;
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-foreground/25 backdrop-blur-sm data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 grid w-[min(100%-2rem,30rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-3xl border border-border bg-card p-6 shadow-2xl duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          className,
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  );
+}
+
+function AlertDialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={cn("flex flex-col gap-1.5", className)} {...props} />;
+}
+
+function AlertDialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)} {...props} />
+  );
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("display-title text-2xl font-semibold text-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return (
+    <AlertDialogPrimitive.Action
+      className={cn(buttonVariants({ variant: "destructive" }), className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: "outline" }), className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+};

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,123 @@
+import * as React from "react";
+import { Dialog as DialogPrimitive } from "radix-ui";
+import { Cancel01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import { cn } from "#/lib/utils";
+import { Button } from "#/components/ui/button";
+
+function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-foreground/20 backdrop-blur-sm data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 grid w-[min(100%-2rem,36rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-3xl border border-border bg-card p-6 shadow-2xl duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton ? (
+          <DialogPrimitive.Close asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              className="absolute top-4 right-4"
+            >
+              <HugeiconsIcon icon={Cancel01Icon} size={16} />
+              <span className="sr-only">Close</span>
+            </Button>
+          </DialogPrimitive.Close>
+        ) : null}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={cn("flex flex-col gap-1.5", className)} {...props} />;
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)} {...props} />
+  );
+}
+
+function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("display-title text-2xl font-semibold text-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,122 @@
+import * as React from "react";
+import { Dialog as DialogPrimitive } from "radix-ui";
+import { Cancel01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import { cn } from "#/lib/utils";
+import { Button } from "#/components/ui/button";
+
+function Sheet({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="sheet" {...props} />;
+}
+
+function SheetTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
+}
+
+function SheetClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="sheet-close" {...props} />;
+}
+
+function SheetPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="sheet-portal" {...props} />;
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-foreground/25 backdrop-blur-sm data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SheetContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <DialogPrimitive.Content
+        data-slot="sheet-content"
+        className={cn(
+          "fixed inset-x-0 bottom-0 z-50 flex h-svh max-h-svh flex-col gap-4 overflow-y-auto rounded-t-[2rem] border border-border bg-card px-5 pt-6 pb-8 shadow-2xl duration-200 data-[state=closed]:animate-out data-[state=closed]:slide-out-to-bottom data-[state=open]:animate-in data-[state=open]:slide-in-from-bottom",
+          className,
+        )}
+        {...props}
+      >
+        <div className="mx-auto h-1.5 w-14 rounded-full bg-border" />
+        {children}
+        {showCloseButton ? (
+          <DialogPrimitive.Close asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              className="absolute top-4 right-4"
+            >
+              <HugeiconsIcon icon={Cancel01Icon} size={16} />
+              <span className="sr-only">Close</span>
+            </Button>
+          </DialogPrimitive.Close>
+        ) : null}
+      </DialogPrimitive.Content>
+    </SheetPortal>
+  );
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={cn("flex flex-col gap-1.5", className)} {...props} />;
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={cn("mt-auto flex flex-col gap-2", className)} {...props} />;
+}
+
+function SheetTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("display-title text-2xl font-semibold text-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetOverlay,
+  SheetPortal,
+  SheetTitle,
+  SheetTrigger,
+};

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+
+import { cn } from "#/lib/utils";
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "flex min-h-24 w-full rounded-md border border-input bg-input/20 px-3 py-2 text-sm text-foreground transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Textarea };

--- a/src/hooks/useShows.ts
+++ b/src/hooks/useShows.ts
@@ -1,5 +1,6 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { api } from "#/lib/api";
+import { queryClient } from "#/lib/queryClient";
 import type { SearchResponse, TvShow } from "#/types/tvShow";
 
 async function fetchShows(): Promise<TvShow[]> {
@@ -13,9 +14,101 @@ async function fetchShows(): Promise<TvShow[]> {
   return data.result;
 }
 
+interface TvShowPayload {
+  title: string;
+  description: string;
+  recommendedAge: number;
+}
+
+interface UpdateShowPayload {
+  current: TvShow;
+  next: TvShowPayload;
+}
+
+export const showQueryKey = ["shows"] as const;
+
+async function createShow(payload: TvShowPayload) {
+  await api.post("/invoke/createAsset", {
+    asset: [
+      {
+        "@assetType": "tvShows",
+        title: payload.title,
+        description: payload.description,
+        recommendedAge: payload.recommendedAge,
+      },
+    ],
+  });
+}
+
+async function updateShow({ current, next }: UpdateShowPayload) {
+  const titleChanged = current.title !== next.title;
+
+  if (titleChanged) {
+    await createShow(next);
+
+    await api.delete("/invoke/deleteAsset", {
+      data: {
+        key: {
+          "@assetType": "tvShows",
+          title: current.title,
+        },
+      },
+    });
+
+    return;
+  }
+
+  await api.put("/invoke/updateAsset", {
+    update: {
+      "@assetType": "tvShows",
+      title: current.title,
+      description: next.description,
+      recommendedAge: next.recommendedAge,
+    },
+  });
+}
+
+async function deleteShow(show: TvShow) {
+  await api.delete("/invoke/deleteAsset", {
+    data: {
+      key: {
+        "@assetType": "tvShows",
+        title: show.title,
+      },
+    },
+  });
+}
+
 export function useShows() {
   return useQuery({
-    queryKey: ["shows"],
+    queryKey: showQueryKey,
     queryFn: fetchShows,
+  });
+}
+
+export function useCreateShow() {
+  return useMutation({
+    mutationFn: createShow,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: showQueryKey });
+    },
+  });
+}
+
+export function useUpdateShow() {
+  return useMutation({
+    mutationFn: updateShow,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: showQueryKey });
+    },
+  });
+}
+
+export function useDeleteShow() {
+  return useMutation({
+    mutationFn: deleteShow,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: showQueryKey });
+    },
   });
 }

--- a/src/lib/api-errors.ts
+++ b/src/lib/api-errors.ts
@@ -1,0 +1,19 @@
+import { AxiosError } from "axios";
+
+interface ApiErrorPayload {
+  error?: string;
+  message?: string;
+}
+
+export function getApiErrorMessage(error: unknown, fallback: string) {
+  if (error instanceof AxiosError) {
+    const payload = error.response?.data as ApiErrorPayload | undefined;
+    return payload?.message ?? payload?.error ?? fallback;
+  }
+
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return fallback;
+}

--- a/src/routes/_auth/shows/index.tsx
+++ b/src/routes/_auth/shows/index.tsx
@@ -7,6 +7,8 @@ import {
   SortByUp01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { DeleteShowDialog } from "#/components/DeleteShowDialog";
+import { ShowFormDialog } from "#/components/ShowFormDialog";
 import { ShowCard, ShowCardSkeleton } from "#/components/ShowCard";
 import { Button } from "#/components/ui/button";
 import { Input } from "#/components/ui/input";
@@ -18,6 +20,7 @@ import {
   SelectValue,
 } from "#/components/ui/select";
 import { useShows } from "#/hooks/useShows";
+import type { TvShow } from "#/types/tvShow";
 
 export const Route = createFileRoute("/_auth/shows/")({
   staticData: { crumb: "Shows" },
@@ -30,6 +33,9 @@ function ShowsPage() {
   const { data: shows, isLoading, isError } = useShows();
   const [search, setSearch] = useState("");
   const [sort, setSort] = useState<SortOrder>("az");
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [editingShow, setEditingShow] = useState<TvShow | null>(null);
+  const [deletingShow, setDeletingShow] = useState<TvShow | null>(null);
 
   const filtered = (shows ?? [])
     .filter(s => s.title.toLowerCase().includes(search.toLowerCase()))
@@ -37,12 +43,13 @@ function ShowsPage() {
       if (sort === "az") return a.title.localeCompare(b.title);
       return b.title.localeCompare(a.title);
     });
+  const allShows = shows ?? [];
 
   return (
     <main className="mx-auto w-full max-w-7xl px-4 py-10">
       <div className="mb-6 flex items-center justify-between gap-4">
         <h1 className="display-title text-3xl font-bold text-foreground">Shows</h1>
-        <Button disabled>New Show</Button>
+        <Button onClick={() => setIsCreateOpen(true)}>New Show</Button>
       </div>
 
       <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center">
@@ -122,10 +129,44 @@ function ShowsPage() {
       {!isLoading && !isError && filtered.length > 0 && (
         <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
           {filtered.map(show => (
-            <ShowCard key={show["@key"]} show={show} />
+            <ShowCard
+              key={show["@key"]}
+              show={show}
+              onEdit={setEditingShow}
+              onDelete={setDeletingShow}
+            />
           ))}
         </div>
       )}
+
+      <ShowFormDialog
+        existingShows={allShows}
+        mode="create"
+        open={isCreateOpen}
+        onOpenChange={setIsCreateOpen}
+      />
+
+      <ShowFormDialog
+        existingShows={allShows}
+        mode="edit"
+        open={Boolean(editingShow)}
+        onOpenChange={open => {
+          if (!open) {
+            setEditingShow(null);
+          }
+        }}
+        show={editingShow}
+      />
+
+      <DeleteShowDialog
+        open={Boolean(deletingShow)}
+        onOpenChange={open => {
+          if (!open) {
+            setDeletingShow(null);
+          }
+        }}
+        show={deletingShow}
+      />
     </main>
   );
 }

--- a/src/schemas/tvShow.ts
+++ b/src/schemas/tvShow.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+import type { TvShow } from "#/types/tvShow";
+
+export function createTvShowSchema(existingShows: TvShow[], currentTitle?: string) {
+  return z
+    .object({
+      title: z.string().trim().min(1, "Title is required"),
+      description: z.string().trim().min(1, "Description is required"),
+      recommendedAge: z.coerce
+        .number({
+          invalid_type_error: "Recommended age is required",
+        })
+        .int("Recommended age must be a whole number")
+        .min(0, "Recommended age cannot be negative"),
+    })
+    .superRefine((value, ctx) => {
+      const normalizedTitle = value.title.toLowerCase();
+      const duplicate = existingShows.some(show => {
+        if (currentTitle && show.title === currentTitle) {
+          return false;
+        }
+
+        return show.title.toLowerCase() === normalizedTitle;
+      });
+
+      if (duplicate) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["title"],
+          message: "A TV show with this title already exists",
+        });
+      }
+    });
+}
+
+export type TvShowFormValues = z.infer<ReturnType<typeof createTvShowSchema>>;

--- a/src/types/tvShow.ts
+++ b/src/types/tvShow.ts
@@ -7,7 +7,7 @@ export interface TvShow {
   "@lastUpdated"?: string;
   title: string;
   description: string;
-  recommendedAge?: number;
+  recommendedAge: number;
 }
 
 export interface SearchResponse<T> {


### PR DESCRIPTION
Closes #6

## Summary

- add responsive in-place TV show create/edit flows via Credenza
- wire show delete confirmation and React Query CRUD mutations on `/shows`
- add shared dialog/sheet/alert-dialog primitives, textarea, and TV show schema/error helpers

## Testing

- `pnpm lint`
- `pnpm build`
- `pnpm test`

## Notes

- `recommendedAge` is now included as a required field to match the live API schema
- title editing is currently locked because the TV show title is the asset key and related assets may still reference it
- live authenticated API verification was only partially exercised during development and may still need a credentials-backed pass