### PR TITLE
feat: TMDB poster integration (#7)

### DIFF
--- a/src/components/ShowCard.tsx
+++ b/src/components/ShowCard.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import { MoreHorizontalIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { useTMDB } from "#/hooks/useTMDB";
 import { Button } from "#/components/ui/button";
 import { Card, CardContent } from "#/components/ui/card";
 import {
@@ -20,13 +21,27 @@ interface ShowCardProps {
 
 export function ShowCard({ show, onEdit, onDelete }: ShowCardProps) {
   const showId = encodeURIComponent(show.title);
+  const { imageUrl } = useTMDB(show.title);
+  const fallbackTone = getPosterFallbackTone(show.title);
 
   return (
     <Card className="group relative flex flex-col pt-0 overflow-hidden transition-shadow hover:shadow-md">
       <Link to="/shows/$showId" params={{ showId }} className="flex flex-col flex-1">
-        <div className="aspect-[2/3] w-full bg-muted" />
+        <div className={`relative aspect-[2/3] w-full overflow-hidden ${fallbackTone}`}>
+          {imageUrl ? (
+            <img
+              src={imageUrl}
+              alt={`${show.title} poster`}
+              className="size-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+              loading="lazy"
+            />
+          ) : null}
+          <div className="absolute inset-0 bg-gradient-to-t from-foreground/70 via-foreground/10 to-transparent" />
+          <div className="absolute inset-x-0 bottom-0 p-3">
+            <p className="line-clamp-2 text-sm font-semibold text-background">{show.title}</p>
+          </div>
+        </div>
         <CardContent className="flex flex-1 flex-col gap-1 p-3">
-          <p className="line-clamp-1 font-semibold leading-snug">{show.title}</p>
           <p className="line-clamp-2 text-xs text-muted-foreground">{show.description}</p>
         </CardContent>
       </Link>
@@ -56,6 +71,23 @@ export function ShowCard({ show, onEdit, onDelete }: ShowCardProps) {
       </div>
     </Card>
   );
+}
+
+function getPosterFallbackTone(title: string) {
+  const fallbackTones = [
+    "bg-gradient-to-br from-primary via-chart-3 to-chart-2",
+    "bg-gradient-to-br from-chart-4 via-primary to-secondary",
+    "bg-gradient-to-br from-chart-2 via-chart-4 to-primary",
+    "bg-gradient-to-br from-foreground via-chart-4 to-primary",
+  ];
+
+  let hash = 0;
+  for (const character of title) {
+    hash = (hash << 5) - hash + character.charCodeAt(0);
+    hash |= 0;
+  }
+
+  return fallbackTones[Math.abs(hash) % fallbackTones.length];
 }
 
 export function ShowCardSkeleton() {

--- a/src/hooks/useTMDB.ts
+++ b/src/hooks/useTMDB.ts
@@ -1,0 +1,49 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { tmdbApi } from "#/lib/tmdb";
+import { tmdbSearchResponseSchema } from "#/schemas/tmdb";
+import { useTMDBStore } from "#/stores/tmdb";
+
+type TMDBImageKind = "poster" | "still";
+
+async function fetchTMDBImage(title: string, kind: TMDBImageKind) {
+  if (!import.meta.env.VITE_TMDB_API_KEY?.trim() || !title.trim()) {
+    return null;
+  }
+
+  const response = await tmdbApi.get("/search/tv", {
+    params: {
+      query: title,
+    },
+  });
+  const data = tmdbSearchResponseSchema.parse(response.data);
+  const firstResult = data.results[0];
+  const imagePath = kind === "poster" ? firstResult?.poster_path : firstResult?.backdrop_path;
+
+  return imagePath ? `https://image.tmdb.org/t/p/w500${imagePath}` : null;
+}
+
+export function useTMDB(title: string, kind: TMDBImageKind = "poster") {
+  const cachedImage = useTMDBStore(state => state.getImage(kind, title));
+  const setImage = useTMDBStore(state => state.setImage);
+  const hasCacheEntry = cachedImage !== undefined;
+
+  const query = useQuery({
+    queryKey: ["tmdb", kind, title],
+    enabled: Boolean(title.trim()) && !hasCacheEntry,
+    staleTime: Infinity,
+    gcTime: Infinity,
+    queryFn: async () => {
+      const imageUrl = await fetchTMDBImage(title, kind);
+      setImage(kind, title, imageUrl);
+      return imageUrl;
+    },
+  });
+
+  return {
+    imageUrl: hasCacheEntry ? (cachedImage ?? null) : (query.data ?? null),
+    isLoading: !hasCacheEntry && query.isLoading,
+    isError: !hasCacheEntry && query.isError,
+    isFromCache: hasCacheEntry,
+  };
+}

--- a/src/lib/tmdb.ts
+++ b/src/lib/tmdb.ts
@@ -1,0 +1,32 @@
+import axios from "axios";
+
+function isBearerToken(value: string) {
+  return value.startsWith("eyJ");
+}
+
+export const tmdbApi = axios.create({
+  baseURL: "https://api.themoviedb.org/3",
+});
+
+tmdbApi.interceptors.request.use(config => {
+  const tmdbKey = import.meta.env.VITE_TMDB_API_KEY?.trim();
+
+  if (!tmdbKey) {
+    return config;
+  }
+
+  config.params = {
+    ...config.params,
+    include_adult: "false",
+    language: "en-US",
+    page: "1",
+  };
+
+  if (isBearerToken(tmdbKey)) {
+    config.headers.Authorization = `Bearer ${tmdbKey}`;
+    return config;
+  }
+
+  config.params.api_key = tmdbKey;
+  return config;
+});

--- a/src/schemas/tmdb.ts
+++ b/src/schemas/tmdb.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const tmdbSearchResultSchema = z.object({
+  poster_path: z.string().nullable().optional(),
+  backdrop_path: z.string().nullable().optional(),
+});
+
+export const tmdbSearchResponseSchema = z.object({
+  results: z.array(tmdbSearchResultSchema).default([]),
+});
+
+export type TMDBSearchResponse = z.infer<typeof tmdbSearchResponseSchema>;

--- a/src/stores/tmdb.ts
+++ b/src/stores/tmdb.ts
@@ -1,0 +1,43 @@
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+type TMDBImageKind = "poster" | "still";
+type TMDBImageValue = string | null;
+
+interface TMDBStoreState {
+  posters: Record<string, TMDBImageValue>;
+  stills: Record<string, TMDBImageValue>;
+  getImage: (kind: TMDBImageKind, title: string) => TMDBImageValue | undefined;
+  setImage: (kind: TMDBImageKind, title: string, imageUrl: TMDBImageValue) => void;
+}
+
+function normalizeTitle(title: string) {
+  return title.trim().toLowerCase();
+}
+
+export const useTMDBStore = create<TMDBStoreState>()(
+  persist(
+    (set, get) => ({
+      posters: {},
+      stills: {},
+      getImage: (kind, title) => {
+        const normalizedTitle = normalizeTitle(title);
+        return kind === "poster" ? get().posters[normalizedTitle] : get().stills[normalizedTitle];
+      },
+      setImage: (kind, title, imageUrl) => {
+        const normalizedTitle = normalizeTitle(title);
+
+        set(state => ({
+          posters:
+            kind === "poster" ? { ...state.posters, [normalizedTitle]: imageUrl } : state.posters,
+          stills:
+            kind === "still" ? { ...state.stills, [normalizedTitle]: imageUrl } : state.stills,
+        }));
+      },
+    }),
+    {
+      name: "tmdb-image-cache",
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+);


### PR DESCRIPTION
Closes #7

## Summary

- add a persistent Zustand TMDB image cache and cache-first `useTMDB` hook
- introduce a dedicated Axios TMDB client plus a proper Zod schema for TMDB search responses
- render TMDB posters on show cards with deterministic semantic-token gradient fallbacks

## Testing

- `pnpm lint`
- `pnpm build`
- live TMDB search sanity check with the local `.env` key

## Notes

- the current `VITE_TMDB_API_KEY` in local `.env` behaves as the TMDB v3 API key and is supported by the integration
- episode still rendering is prepared at the hook/store level, but the actual episode list UI lands in later slices