### PR TITLE
feat: show detail hero and season tabs (#8)

### DIFF
--- a/src/components/Credenza.tsx
+++ b/src/components/Credenza.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import type { ComponentProps } from "react";
 
 import {
   Dialog,
@@ -10,90 +10,54 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "#/components/ui/dialog";
-import {
-  Sheet,
-  SheetClose,
-  SheetContent,
-  SheetDescription,
-  SheetFooter,
-  SheetHeader,
-  SheetTitle,
-  SheetTrigger,
-} from "#/components/ui/sheet";
+import { cn } from "#/lib/utils";
 
-function useIsDesktop() {
-  const [isDesktop, setIsDesktop] = React.useState(false);
-
-  React.useEffect(() => {
-    const mediaQuery = window.matchMedia("(min-width: 768px)");
-    const updateMatches = () => setIsDesktop(mediaQuery.matches);
-
-    updateMatches();
-    mediaQuery.addEventListener("change", updateMatches);
-
-    return () => mediaQuery.removeEventListener("change", updateMatches);
-  }, []);
-
-  return isDesktop;
+function Credenza(props: ComponentProps<typeof Dialog>) {
+  return <Dialog {...props} />;
 }
 
-function Credenza({ children, ...props }: React.ComponentProps<typeof Dialog>) {
-  const isDesktop = useIsDesktop();
-  const Root = isDesktop ? Dialog : Sheet;
-
-  return <Root {...props}>{children}</Root>;
+function CredenzaTrigger(props: ComponentProps<typeof DialogTrigger>) {
+  return <DialogTrigger {...props} />;
 }
 
-function CredenzaTrigger({ children, ...props }: React.ComponentProps<typeof DialogTrigger>) {
-  const isDesktop = useIsDesktop();
-  const Trigger = isDesktop ? DialogTrigger : SheetTrigger;
-
-  return <Trigger {...props}>{children}</Trigger>;
+function CredenzaClose(props: ComponentProps<typeof DialogClose>) {
+  return <DialogClose {...props} />;
 }
 
-function CredenzaClose({ children, ...props }: React.ComponentProps<typeof DialogClose>) {
-  const isDesktop = useIsDesktop();
-  const Close = isDesktop ? DialogClose : SheetClose;
-
-  return <Close {...props}>{children}</Close>;
+function CredenzaContent({ className, ...props }: ComponentProps<typeof DialogContent>) {
+  return (
+    <DialogContent
+      className={cn(
+        "top-auto bottom-0 left-0 w-full max-w-none translate-x-0 translate-y-0 rounded-t-[2rem] rounded-b-none border-x-0 border-b-0 px-5 py-6 md:top-1/2 md:bottom-auto md:left-1/2 md:w-[min(100%-2rem,36rem)] md:max-w-[36rem] md:-translate-x-1/2 md:-translate-y-1/2 md:rounded-[2rem] md:border md:px-6 md:pt-6 md:pb-8",
+        className,
+      )}
+      {...props}
+    />
+  );
 }
 
-function CredenzaContent({ children, ...props }: React.ComponentProps<typeof DialogContent>) {
-  const isDesktop = useIsDesktop();
-  const Content = isDesktop ? DialogContent : SheetContent;
-
-  return <Content {...props}>{children}</Content>;
+function CredenzaHeader(props: ComponentProps<"div">) {
+  return <DialogHeader {...props} />;
 }
 
-function CredenzaHeader({ children, ...props }: React.ComponentProps<"div">) {
-  const isDesktop = useIsDesktop();
-  const Header = isDesktop ? DialogHeader : SheetHeader;
-
-  return <Header {...props}>{children}</Header>;
+function CredenzaFooter({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <DialogFooter
+      className={cn(
+        "flex-col gap-2 sm:flex-col sm:justify-start md:flex-row md:justify-end",
+        className,
+      )}
+      {...props}
+    />
+  );
 }
 
-function CredenzaFooter({ children, ...props }: React.ComponentProps<"div">) {
-  const isDesktop = useIsDesktop();
-  const Footer = isDesktop ? DialogFooter : SheetFooter;
-
-  return <Footer {...props}>{children}</Footer>;
+function CredenzaTitle(props: ComponentProps<typeof DialogTitle>) {
+  return <DialogTitle {...props} />;
 }
 
-function CredenzaTitle({ children, ...props }: React.ComponentProps<typeof DialogTitle>) {
-  const isDesktop = useIsDesktop();
-  const Title = isDesktop ? DialogTitle : SheetTitle;
-
-  return <Title {...props}>{children}</Title>;
-}
-
-function CredenzaDescription({
-  children,
-  ...props
-}: React.ComponentProps<typeof DialogDescription>) {
-  const isDesktop = useIsDesktop();
-  const Description = isDesktop ? DialogDescription : SheetDescription;
-
-  return <Description {...props}>{children}</Description>;
+function CredenzaDescription(props: ComponentProps<typeof DialogDescription>) {
+  return <DialogDescription {...props} />;
 }
 
 export {

--- a/src/components/DeleteShowDialog.tsx
+++ b/src/components/DeleteShowDialog.tsx
@@ -18,9 +18,10 @@ interface DeleteShowDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   show: TvShow | null;
+  onDeleted?: () => void;
 }
 
-export function DeleteShowDialog({ open, onOpenChange, show }: DeleteShowDialogProps) {
+export function DeleteShowDialog({ open, onOpenChange, show, onDeleted }: DeleteShowDialogProps) {
   const deleteShow = useDeleteShow();
 
   async function handleDelete() {
@@ -32,6 +33,7 @@ export function DeleteShowDialog({ open, onOpenChange, show }: DeleteShowDialogP
       await deleteShow.mutateAsync(show);
       toast.success(`"${show.title}" was removed from the catalogue.`);
       onOpenChange(false);
+      onDeleted?.();
     } catch (error) {
       const message = getApiErrorMessage(error, "Could not delete the TV show.");
 

--- a/src/components/ShowCard.tsx
+++ b/src/components/ShowCard.tsx
@@ -26,7 +26,12 @@ export function ShowCard({ show, onEdit, onDelete }: ShowCardProps) {
 
   return (
     <Card className="group relative flex flex-col pt-0 overflow-hidden transition-shadow hover:shadow-md">
-      <Link to="/shows/$showId" params={{ showId }} className="flex flex-col flex-1">
+      <Link
+        to="/shows/$showId"
+        params={{ showId }}
+        search={{ season: undefined }}
+        className="flex flex-col flex-1"
+      >
         <div className={`relative aspect-[2/3] w-full overflow-hidden ${fallbackTone}`}>
           {imageUrl ? (
             <img

--- a/src/components/ShowFormDialog.tsx
+++ b/src/components/ShowFormDialog.tsx
@@ -1,5 +1,4 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 
@@ -42,24 +41,15 @@ export function ShowFormDialog({
   const {
     register,
     handleSubmit,
-    reset,
     formState: { errors },
   } = useForm<TvShowFormValues>({
     resolver: zodResolver(createTvShowSchema(existingShows, currentTitle)),
-    defaultValues: {
+    values: {
       title: show?.title ?? "",
       description: show?.description ?? "",
       recommendedAge: show?.recommendedAge ?? 16,
     },
   });
-
-  useEffect(() => {
-    reset({
-      title: show?.title ?? "",
-      description: show?.description ?? "",
-      recommendedAge: show?.recommendedAge ?? 16,
-    });
-  }, [open, reset, show]);
 
   async function onSubmit(values: TvShowFormValues) {
     try {
@@ -79,11 +69,6 @@ export function ShowFormDialog({
       }
 
       onOpenChange(false);
-      reset({
-        title: values.title,
-        description: values.description,
-        recommendedAge: values.recommendedAge,
-      });
     } catch (error) {
       toast.error(
         getApiErrorMessage(

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -52,7 +52,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-[min(100%-2rem,36rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-3xl border border-border bg-card p-6 shadow-2xl duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "fixed top-1/2 left-1/2 z-50 flex max-h-[calc(100vh-2rem)] w-[min(100%-2rem,36rem)] -translate-x-1/2 -translate-y-1/2 flex-col gap-4 overflow-y-auto rounded-3xl border border-border bg-card p-6 shadow-2xl duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           className,
         )}
         {...props}

--- a/src/hooks/useShowDetail.ts
+++ b/src/hooks/useShowDetail.ts
@@ -1,0 +1,77 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { api } from "#/lib/api";
+import type { Episode } from "#/types/episode";
+import type { Season } from "#/types/season";
+import type { SearchResponse, TvShow } from "#/types/tvShow";
+
+export const getShowDetailQueryKey = (showTitle: string) => ["show", showTitle] as const;
+
+async function fetchShow(showTitle: string): Promise<TvShow> {
+  const { data } = await api.post<TvShow>("/query/readAsset", {
+    key: {
+      "@assetType": "tvShows",
+      title: showTitle,
+    },
+  });
+
+  return data;
+}
+
+async function fetchSeasons(showKey: string): Promise<Season[]> {
+  const { data } = await api.post<SearchResponse<Season>>("/query/search", {
+    query: {
+      selector: {
+        "@assetType": "seasons",
+      },
+      limit: 200,
+    },
+  });
+
+  return data.result
+    .filter(season => season.tvShow?.["@key"] === showKey)
+    .sort((left, right) => left.number - right.number);
+}
+
+async function fetchEpisodes(seasonKeys: string[]): Promise<Episode[]> {
+  if (seasonKeys.length === 0) {
+    return [];
+  }
+
+  const { data } = await api.post<SearchResponse<Episode>>("/query/search", {
+    query: {
+      selector: {
+        "@assetType": "episodes",
+      },
+      limit: 500,
+    },
+  });
+
+  return data.result
+    .filter(episode => seasonKeys.includes(episode.season?.["@key"] ?? ""))
+    .sort((left, right) => left.episodeNumber - right.episodeNumber);
+}
+
+export function useShow(showTitle: string) {
+  return useQuery({
+    queryKey: getShowDetailQueryKey(showTitle),
+    enabled: Boolean(showTitle),
+    queryFn: () => fetchShow(showTitle),
+  });
+}
+
+export function useSeasons(showKey?: string) {
+  return useQuery({
+    queryKey: ["seasons", showKey],
+    enabled: Boolean(showKey),
+    queryFn: () => fetchSeasons(showKey!),
+  });
+}
+
+export function useEpisodes(seasonKeys: string[]) {
+  return useQuery({
+    queryKey: ["episodes", ...seasonKeys],
+    enabled: seasonKeys.length > 0,
+    queryFn: () => fetchEpisodes(seasonKeys),
+  });
+}

--- a/src/hooks/useShows.ts
+++ b/src/hooks/useShows.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
+import { getShowDetailQueryKey } from "#/hooks/useShowDetail";
 import { api } from "#/lib/api";
 import { queryClient } from "#/lib/queryClient";
 import type { SearchResponse, TvShow } from "#/types/tvShow";
@@ -98,8 +99,11 @@ export function useCreateShow() {
 export function useUpdateShow() {
   return useMutation({
     mutationFn: updateShow,
-    onSuccess: async () => {
+    onSuccess: async (_, variables) => {
       await queryClient.invalidateQueries({ queryKey: showQueryKey });
+      await queryClient.invalidateQueries({
+        queryKey: getShowDetailQueryKey(variables.current.title),
+      });
     },
   });
 }

--- a/src/routes/_auth/shows/$showId/index.tsx
+++ b/src/routes/_auth/shows/$showId/index.tsx
@@ -1,15 +1,502 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { useMemo, useState, useSyncExternalStore, type CSSProperties } from "react";
+import { Link, Navigate, createFileRoute } from "@tanstack/react-router";
+import { Calendar03Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import { DeleteShowDialog } from "#/components/DeleteShowDialog";
+import { ShowFormDialog } from "#/components/ShowFormDialog";
+import { Button } from "#/components/ui/button";
+import { Skeleton } from "#/components/ui/skeleton";
+import { useEpisodes, useSeasons, useShow } from "#/hooks/useShowDetail";
+import { useShows } from "#/hooks/useShows";
+import { useTMDB } from "#/hooks/useTMDB";
+import type { Episode } from "#/types/episode";
+import type { Season } from "#/types/season";
+import type { TvShow } from "#/types/tvShow";
+
+const MOBILE_POSTER_MIN_HEIGHT_REM = 18;
+const MOBILE_POSTER_MAX_HEIGHT_REM = 27;
+const MOBILE_POSTER_SCROLL_RANGE_PX = 220;
 
 export const Route = createFileRoute("/_auth/shows/$showId/")({
+  staticData: { crumb: "Show" },
+  validateSearch: search => ({
+    season:
+      typeof search.season === "number"
+        ? search.season
+        : typeof search.season === "string" && search.season.trim()
+          ? Number(search.season)
+          : undefined,
+  }),
+  loader: ({ params }) => ({
+    crumb: decodeURIComponent(params.showId),
+  }),
   component: ShowDetailPage,
 });
 
 function ShowDetailPage() {
   const { showId } = Route.useParams();
+  const decodedShowId = decodeURIComponent(showId);
+  const search = Route.useSearch();
+  const navigate = Route.useNavigate();
+  const { data: allShows = [] } = useShows();
+  const [isEditOpen, setIsEditOpen] = useState(false);
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+
+  const { data: show, isLoading: isShowLoading, isError: isShowError } = useShow(decodedShowId);
+  const { imageUrl: posterUrl } = useTMDB(show?.title ?? decodedShowId, "poster");
+  const {
+    data: seasons = [],
+    isLoading: isSeasonsLoading,
+    isError: isSeasonsError,
+  } = useSeasons(show?.["@key"]);
+  const activeSeason = getActiveSeason(seasons, search.season);
+  const seasonKeys = seasons.map(season => season["@key"]);
+  const {
+    data: episodes = [],
+    isLoading: isEpisodesLoading,
+    isError: isEpisodesError,
+  } = useEpisodes(seasonKeys);
+  const visibleEpisodes = useMemo(
+    () =>
+      activeSeason
+        ? episodes.filter(episode => episode.season["@key"] === activeSeason["@key"])
+        : [],
+    [activeSeason, episodes],
+  );
+
+  if (!search.season && seasons[0]) {
+    return (
+      <Navigate
+        to="/shows/$showId"
+        params={{ showId }}
+        search={{ season: seasons[0].number }}
+        replace
+      />
+    );
+  }
+
   return (
-    <main className="mx-auto max-w-5xl px-4 py-10">
-      <h1 className="display-title text-3xl font-bold text-foreground">{showId}</h1>
-      <p className="mt-2 text-muted-foreground">Coming in slice 7.</p>
+    <main className="pb-16 md:pb-10">
+      <ShowHero
+        show={show}
+        fallbackTitle={decodedShowId}
+        posterUrl={posterUrl}
+        isLoading={isShowLoading}
+        isError={isShowError}
+        onEdit={() => setIsEditOpen(true)}
+        onDelete={() => setIsDeleteOpen(true)}
+      />
+
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-8">
+        <section className="flex flex-col gap-4">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <p className="text-xs font-semibold tracking-[0.24em] uppercase text-muted-foreground">
+                Seasons
+              </p>
+              <h2 className="display-title text-2xl font-semibold text-foreground">
+                Browse the catalogue
+              </h2>
+            </div>
+            <Button disabled>Add Season</Button>
+          </div>
+
+          {isSeasonsLoading ? <SeasonTabsSkeleton /> : null}
+          {isSeasonsError ? (
+            <p className="text-sm text-destructive">Failed to load seasons. Please try again.</p>
+          ) : null}
+
+          {!isSeasonsLoading && !isSeasonsError && seasons.length === 0 ? (
+            <EmptySeasonState />
+          ) : null}
+
+          {!isSeasonsLoading && !isSeasonsError && seasons.length > 0 ? (
+            <>
+              <div className="flex flex-wrap gap-2 rounded-3xl border border-border bg-card/80 p-2">
+                {seasons.map(season => {
+                  const isActive = season["@key"] === activeSeason?.["@key"];
+
+                  return (
+                    <button
+                      key={season["@key"]}
+                      type="button"
+                      onClick={() =>
+                        navigate({
+                          to: "/shows/$showId",
+                          params: { showId },
+                          search: { season: season.number },
+                        })
+                      }
+                      className={
+                        isActive
+                          ? "rounded-full bg-primary px-4 py-2 text-sm font-medium text-primary-foreground text-shadow-md"
+                          : "rounded-full bg-muted px-4 py-2 text-sm font-medium text-muted-foreground text-shadow-md transition-colors hover:bg-secondary hover:text-foreground"
+                      }
+                    >
+                      Season {season.number}
+                    </button>
+                  );
+                })}
+              </div>
+
+              {isEpisodesLoading ? <EpisodeListSkeleton /> : null}
+              {isEpisodesError ? (
+                <p className="text-sm text-destructive">
+                  Failed to load episodes. Please try again.
+                </p>
+              ) : null}
+              {!isEpisodesLoading && !isEpisodesError ? (
+                <EpisodeList episodes={visibleEpisodes} season={activeSeason} showId={showId} />
+              ) : null}
+            </>
+          ) : null}
+        </section>
+      </div>
+
+      <ShowFormDialog
+        existingShows={allShows}
+        mode="edit"
+        open={isEditOpen}
+        onOpenChange={setIsEditOpen}
+        show={show}
+      />
+      <DeleteShowDialog
+        open={isDeleteOpen}
+        onOpenChange={setIsDeleteOpen}
+        show={show ?? null}
+        onDeleted={() =>
+          navigate({
+            to: "/shows",
+          })
+        }
+      />
     </main>
   );
+}
+
+function ShowHero({
+  show,
+  fallbackTitle,
+  posterUrl,
+  isLoading,
+  isError,
+  onEdit,
+  onDelete,
+}: {
+  show?: TvShow;
+  fallbackTitle: string;
+  posterUrl: string | null;
+  isLoading: boolean;
+  isError: boolean;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const heroTone = getHeroTone(show?.title ?? fallbackTitle);
+  const sectionTone = posterUrl ? "bg-background" : heroTone;
+  const scrollY = useWindowScrollY();
+  const mobilePosterHeight = getMobilePosterHeight(scrollY);
+  const mobilePosterWidth = (mobilePosterHeight * 2) / 3;
+  const mobilePosterStyle = {
+    "--mobile-poster-height": `${mobilePosterHeight}rem`,
+    "--mobile-poster-width": `${mobilePosterWidth}rem`,
+  } satisfies CSSProperties;
+
+  return (
+    <section className={`relative overflow-hidden border-b border-border ${sectionTone}`}>
+      {posterUrl ? (
+        <img
+          src={posterUrl}
+          alt=""
+          aria-hidden="true"
+          className="absolute inset-0 size-full blur-sm object-cover opacity-70"
+        />
+      ) : null}
+      <div className="absolute inset-0 bg-gradient-to-b from-background/5 via-background/35 to-background" />
+      <div className="relative mx-auto flex min-h-[24rem] w-full max-w-7xl flex-col justify-end gap-6 px-4 py-10 md:min-h-[28rem] md:flex-row md:items-end">
+        <div
+          className="h-[var(--mobile-poster-height)] w-[var(--mobile-poster-width)] shrink-0 self-center md:h-[22rem] md:w-[15rem] md:self-auto"
+          style={mobilePosterStyle}
+        >
+          {posterUrl ? (
+            <div className="overflow-hidden rounded-[1.75rem] border border-background/20 shadow-2xl">
+              <img
+                src={posterUrl}
+                alt={`${show?.title ?? fallbackTitle} poster`}
+                className="h-full w-full object-cover md:h-[22rem] md:w-[15rem]"
+              />
+            </div>
+          ) : (
+            <div
+              className={`h-full w-full rounded-[1.75rem] border border-background/20 shadow-2xl md:h-[22rem] md:w-[15rem] ${heroTone}`}
+            />
+          )}
+        </div>
+
+        <div className="max-w-3xl space-y-4 md:pb-2">
+          <p className="text-shadow-sm text-xs font-semibold tracking-[0.24em] uppercase text-white/80">
+            Show Detail
+          </p>
+          {isLoading ? <Skeleton className="h-12 w-3/4 bg-background/20" /> : null}
+          {!isLoading ? (
+            <h1 className="display-title text-4xl font-bold text-shadow-md text-white md:text-6xl">
+              {show?.title ?? fallbackTitle}
+            </h1>
+          ) : null}
+          {isLoading ? <Skeleton className="h-20 w-full max-w-2xl bg-background/20" /> : null}
+          {!isLoading ? (
+            <p className="max-w-2xl text-sm leading-7 text-shadow-sm text-white/88 md:text-base">
+              {show?.description ?? "No description available."}
+            </p>
+          ) : null}
+          {isError ? (
+            <p className="text-sm font-medium text-shadow-sm text-white/80">
+              Failed to load this show.
+            </p>
+          ) : null}
+        </div>
+
+        <div className="flex flex-wrap gap-2 md:ml-auto md:self-end">
+          <Button variant="secondary" onClick={onEdit} disabled={!show}>
+            Edit Show
+          </Button>
+          <Button variant="secondary" onClick={onDelete} disabled={!show}>
+            Delete Show
+          </Button>
+          <Button variant="outline" disabled>
+            + Watchlist
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function useWindowScrollY() {
+  return useSyncExternalStore(subscribeToWindowScroll, getWindowScrollY, () => 0);
+}
+
+function subscribeToWindowScroll(onStoreChange: () => void) {
+  if (typeof window === "undefined") {
+    return () => {};
+  }
+
+  window.addEventListener("scroll", onStoreChange, { passive: true });
+  window.addEventListener("resize", onStoreChange, { passive: true });
+
+  return () => {
+    window.removeEventListener("scroll", onStoreChange);
+    window.removeEventListener("resize", onStoreChange);
+  };
+}
+
+function getWindowScrollY() {
+  if (typeof window === "undefined") {
+    return 0;
+  }
+
+  return window.scrollY;
+}
+
+function getMobilePosterHeight(scrollY: number) {
+  const progress = clamp(scrollY / MOBILE_POSTER_SCROLL_RANGE_PX, 0, 1);
+  return (
+    MOBILE_POSTER_MAX_HEIGHT_REM -
+    (MOBILE_POSTER_MAX_HEIGHT_REM - MOBILE_POSTER_MIN_HEIGHT_REM) * progress
+  );
+}
+
+function EpisodeList({
+  episodes,
+  season,
+  showId,
+}: {
+  episodes: Episode[];
+  season?: Season;
+  showId: string;
+}) {
+  if (!season) {
+    return null;
+  }
+
+  if (episodes.length === 0) {
+    return (
+      <div className="rounded-3xl border border-dashed border-border bg-card/50 px-6 py-12 text-center">
+        <p className="display-title text-2xl font-semibold text-foreground">No episodes yet</p>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Season {season.number} is ready for its first episode.
+        </p>
+        <Button className="mt-4" disabled>
+          Add an Episode
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {episodes.map(episode => (
+        <EpisodeRow key={episode["@key"]} episode={episode} season={season} showId={showId} />
+      ))}
+    </div>
+  );
+}
+
+function EpisodeRow({
+  episode,
+  season,
+  showId,
+}: {
+  episode: Episode;
+  season: Season;
+  showId: string;
+}) {
+  const { imageUrl: stillUrl } = useTMDB(episode.title, "still");
+
+  return (
+    <Link
+      to="/shows/$showId/episodes/$episode"
+      params={{
+        showId,
+        episode: `s${season.number}e${episode.episodeNumber}`,
+      }}
+      className="block"
+    >
+      <article className="grid gap-4 rounded-3xl border border-border bg-card/80 p-4 transition-colors hover:bg-card md:grid-cols-[10rem_1fr]">
+        <div className="relative aspect-video overflow-hidden rounded-2xl">
+          {stillUrl ? (
+            <img
+              src={stillUrl}
+              alt=""
+              aria-hidden="true"
+              className="absolute inset-0 size-full object-cover"
+            />
+          ) : (
+            <div className={`absolute inset-0 ${getEpisodeTone(episode.title)}`} />
+          )}
+          <div className="absolute inset-0 bg-linear-to-t from-foreground/30 via-transparent to-transparent" />
+        </div>
+        <div className="flex flex-col gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="rounded-full bg-muted px-2.5 py-1 text-[0.65rem] font-semibold tracking-[0.2em] uppercase text-muted-foreground">
+              Episode {episode.episodeNumber}
+            </span>
+            {episode.rating !== undefined ? (
+              <span className="rounded-full bg-primary/10 px-2.5 py-1 text-[0.65rem] font-semibold tracking-[0.16em] uppercase text-primary">
+                Rating {episode.rating.toFixed(1)}
+              </span>
+            ) : null}
+          </div>
+          <h3 className="text-lg font-semibold text-foreground">{episode.title}</h3>
+          <p className="line-clamp-2 text-sm text-muted-foreground">{episode.description}</p>
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <HugeiconsIcon icon={Calendar03Icon} size={14} />
+            <span>{formatDate(episode.releaseDate)}</span>
+          </div>
+        </div>
+      </article>
+    </Link>
+  );
+}
+
+function SeasonTabsSkeleton() {
+  return (
+    <div className="flex flex-wrap gap-2 rounded-3xl border border-border bg-card/80 p-2">
+      {Array.from({ length: 4 }).map((_, index) => (
+        <Skeleton key={index} className="h-10 w-28 rounded-full" />
+      ))}
+    </div>
+  );
+}
+
+function EpisodeListSkeleton() {
+  return (
+    <div className="flex flex-col gap-3">
+      {Array.from({ length: 3 }).map((_, index) => (
+        <div
+          key={index}
+          className="grid gap-4 rounded-3xl border border-border bg-card/80 p-4 md:grid-cols-[10rem_1fr]"
+        >
+          <Skeleton className="aspect-video rounded-2xl" />
+          <div className="flex flex-col gap-3">
+            <Skeleton className="h-5 w-40" />
+            <Skeleton className="h-6 w-3/5" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-2/3" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function EmptySeasonState() {
+  return (
+    <div className="rounded-3xl border border-dashed border-border bg-card/50 px-6 py-12 text-center">
+      <p className="display-title text-2xl font-semibold text-foreground">No seasons yet</p>
+      <p className="mt-2 text-sm text-muted-foreground">This show is ready for its first season.</p>
+      <Button className="mt-4" disabled>
+        Add a Season
+      </Button>
+    </div>
+  );
+}
+
+function getActiveSeason(seasons: Season[], requestedSeason?: number) {
+  if (requestedSeason) {
+    return seasons.find(season => season.number === requestedSeason) ?? seasons[0];
+  }
+
+  return seasons[0];
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function formatDate(value: string) {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return "Unknown date";
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(date);
+}
+
+function getHeroTone(seed: string) {
+  const tones = [
+    "bg-gradient-to-br from-primary via-chart-4 to-foreground",
+    "bg-gradient-to-br from-chart-2 via-primary to-chart-3",
+    "bg-gradient-to-br from-chart-4 via-foreground to-primary",
+    "bg-gradient-to-br from-primary via-chart-3 to-chart-1",
+  ];
+
+  return tones[Math.abs(hashString(seed)) % tones.length];
+}
+
+function getEpisodeTone(seed: string) {
+  const tones = [
+    "bg-gradient-to-br from-primary/80 via-chart-4/80 to-foreground/80",
+    "bg-gradient-to-br from-chart-2/80 via-primary/70 to-chart-3/80",
+    "bg-gradient-to-br from-chart-4/70 via-foreground/70 to-primary/70",
+    "bg-gradient-to-br from-primary/70 via-chart-3/70 to-chart-1/80",
+  ];
+
+  return tones[Math.abs(hashString(seed)) % tones.length];
+}
+
+function hashString(value: string) {
+  let hash = 0;
+
+  for (const character of value) {
+    hash = (hash << 5) - hash + character.charCodeAt(0);
+    hash |= 0;
+  }
+
+  return hash;
 }

--- a/src/stores/tmdb.ts
+++ b/src/stores/tmdb.ts
@@ -36,7 +36,7 @@ export const useTMDBStore = create<TMDBStoreState>()(
       },
     }),
     {
-      name: "tmdb-image-cache",
+      name: "tmdb-image-cache-v2",
       storage: createJSONStorage(() => localStorage),
     },
   ),

--- a/src/types/episode.ts
+++ b/src/types/episode.ts
@@ -1,0 +1,16 @@
+import type { SeasonReference } from "#/types/season";
+
+export interface Episode {
+  "@assetType": "episodes";
+  "@key": string;
+  "@lastTouchBy"?: string;
+  "@lastTx"?: string;
+  "@lastTxID"?: string;
+  "@lastUpdated"?: string;
+  season: SeasonReference;
+  episodeNumber: number;
+  title: string;
+  releaseDate: string;
+  description: string;
+  rating?: number;
+}

--- a/src/types/season.ts
+++ b/src/types/season.ts
@@ -1,0 +1,21 @@
+export interface SeasonReference {
+  "@assetType": "seasons";
+  "@key": string;
+}
+
+export interface TvShowReference {
+  "@assetType": "tvShows";
+  "@key": string;
+}
+
+export interface Season {
+  "@assetType": "seasons";
+  "@key": string;
+  "@lastTouchBy"?: string;
+  "@lastTx"?: string;
+  "@lastTxID"?: string;
+  "@lastUpdated"?: string;
+  number: number;
+  tvShow: TvShowReference;
+  year: number;
+}


### PR DESCRIPTION
Closes #8

## Summary
- add the TV show detail route with a TMDB-backed hero and season tab navigation
- load show, season, and episode data from the GoLedger API with dedicated detail hooks and types
- wire the detail page into existing edit and delete flows, including redirecting back to `/shows` after delete

## UI details
- render a cinematic hero with poster artwork, white typography, and subtle text shadows
- show season tabs, episode rows, loading states, and empty states for missing seasons or episodes
- add a mobile poster treatment that centers the poster and shrinks it as the user scrolls

## Technical notes
- use client-side filtering for seasons and episodes based on referenced `@key` values, since nested selectors were not reliable with the current backend responses
- invalidate the show detail query after edits so the page refreshes immediately with the saved data
- satisfy TanStack Router route typing for show-card navigation and show detail search state

## Verification
- `pnpm lint`
- `pnpm build`