### PR TITLE
feat: Episodes list and CRUD (#10)

### DIFF
--- a/src/components/DeleteEpisodeDialog.tsx
+++ b/src/components/DeleteEpisodeDialog.tsx
@@ -1,0 +1,67 @@
+import { toast } from "sonner";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "#/components/ui/alert-dialog";
+import { useDeleteEpisode } from "#/hooks/useEpisodes";
+import { getApiErrorMessage } from "#/lib/api-errors";
+import type { Episode } from "#/types/episode";
+
+interface DeleteEpisodeDialogProps {
+  episode: Episode | null;
+  onDeleted?: () => void;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+}
+
+export function DeleteEpisodeDialog({
+  episode,
+  onDeleted,
+  onOpenChange,
+  open,
+}: DeleteEpisodeDialogProps) {
+  const deleteEpisode = useDeleteEpisode();
+
+  async function handleDelete() {
+    if (!episode) {
+      return;
+    }
+
+    try {
+      await deleteEpisode.mutateAsync(episode);
+      toast.success(`Episode ${episode.episodeNumber} was removed successfully.`);
+      onOpenChange(false);
+      onDeleted?.();
+    } catch (error) {
+      toast.error(getApiErrorMessage(error, "Could not delete the episode."));
+    }
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete episode?</AlertDialogTitle>
+          <AlertDialogDescription>
+            {episode
+              ? `This will permanently remove Episode ${episode.episodeNumber}, "${episode.title}".`
+              : "This will permanently remove the selected episode."}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={deleteEpisode.isPending}>Cancel</AlertDialogCancel>
+          <AlertDialogAction disabled={deleteEpisode.isPending} onClick={handleDelete}>
+            {deleteEpisode.isPending ? "Deleting..." : "Delete Episode"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/EpisodeFormDialog.tsx
+++ b/src/components/EpisodeFormDialog.tsx
@@ -1,0 +1,227 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+
+import {
+  Credenza,
+  CredenzaContent,
+  CredenzaDescription,
+  CredenzaFooter,
+  CredenzaHeader,
+  CredenzaTitle,
+} from "#/components/Credenza";
+import { Button } from "#/components/ui/button";
+import { Input } from "#/components/ui/input";
+import { Label } from "#/components/ui/label";
+import { Textarea } from "#/components/ui/textarea";
+import { useCreateEpisode, useUpdateEpisode } from "#/hooks/useEpisodes";
+import { getApiErrorMessage } from "#/lib/api-errors";
+import { createEpisodeSchema, type EpisodeFormValues } from "#/schemas/episode";
+import type { Episode } from "#/types/episode";
+import type { SeasonReference } from "#/types/season";
+
+interface EpisodeFormDialogProps {
+  existingEpisodes: Episode[];
+  mode: "create" | "edit";
+  onOpenChange: (open: boolean) => void;
+  onSubmitted?: (episodeNumber: number) => void;
+  open: boolean;
+  episode?: Episode | null;
+  season: SeasonReference | null;
+}
+
+export function EpisodeFormDialog({
+  existingEpisodes,
+  mode,
+  onOpenChange,
+  onSubmitted,
+  open,
+  episode,
+  season,
+}: EpisodeFormDialogProps) {
+  const createEpisode = useCreateEpisode();
+  const updateEpisode = useUpdateEpisode();
+  const currentEpisode = mode === "edit" ? (episode ?? null) : null;
+  const {
+    formState: { errors },
+    handleSubmit,
+    register,
+  } = useForm<EpisodeFormValues>({
+    resolver: zodResolver(createEpisodeSchema(existingEpisodes, currentEpisode)),
+    values: {
+      episodeNumber: episode?.episodeNumber ?? existingEpisodes.length + 1,
+      title: episode?.title ?? "",
+      releaseDate: toDateTimeLocalValue(episode?.releaseDate),
+      description: episode?.description ?? "",
+      rating: episode?.rating,
+    },
+  });
+
+  async function onSubmit(values: EpisodeFormValues) {
+    if (!season) {
+      return;
+    }
+
+    try {
+      const payload = {
+        episodeNumber: values.episodeNumber,
+        title: values.title,
+        releaseDate: toIsoDateString(values.releaseDate),
+        description: values.description,
+        rating: values.rating,
+      };
+
+      if (mode === "create") {
+        await createEpisode.mutateAsync({
+          season,
+          ...payload,
+        });
+        toast.success(`Episode ${values.episodeNumber} was created successfully.`);
+      } else if (episode) {
+        await updateEpisode.mutateAsync({
+          current: episode,
+          next: payload,
+        });
+        toast.success(`Episode ${values.episodeNumber} was updated successfully.`);
+      }
+
+      onOpenChange(false);
+      onSubmitted?.(values.episodeNumber);
+    } catch (error) {
+      toast.error(
+        getApiErrorMessage(
+          error,
+          mode === "create" ? "Could not create the episode." : "Could not update the episode.",
+        ),
+      );
+    }
+  }
+
+  const isPending = createEpisode.isPending || updateEpisode.isPending;
+  const title = mode === "create" ? "Add Episode" : "Edit Episode";
+  const description =
+    mode === "create"
+      ? "Add a new episode to this season with its title, date, and details."
+      : "Update this episode without leaving the show detail page.";
+  const actionLabel = mode === "create" ? "Create Episode" : "Save Changes";
+
+  return (
+    <Credenza open={open} onOpenChange={onOpenChange}>
+      <CredenzaContent>
+        <CredenzaHeader>
+          <CredenzaTitle>{title}</CredenzaTitle>
+          <CredenzaDescription>{description}</CredenzaDescription>
+        </CredenzaHeader>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-5" noValidate>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="episode-number">Episode number</Label>
+            <Input
+              id="episode-number"
+              type="number"
+              min={1}
+              step={1}
+              aria-invalid={Boolean(errors.episodeNumber)}
+              {...register("episodeNumber", { valueAsNumber: true })}
+            />
+            {errors.episodeNumber ? (
+              <p className="text-sm text-destructive">{errors.episodeNumber.message}</p>
+            ) : null}
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="episode-title">Title</Label>
+            <Input
+              id="episode-title"
+              aria-invalid={Boolean(errors.title)}
+              placeholder="Pilot"
+              {...register("title")}
+            />
+            {errors.title ? (
+              <p className="text-sm text-destructive">{errors.title.message}</p>
+            ) : null}
+          </div>
+
+          <div className="grid gap-5 md:grid-cols-2">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="episode-release-date">Release date</Label>
+              <Input
+                id="episode-release-date"
+                type="datetime-local"
+                aria-invalid={Boolean(errors.releaseDate)}
+                {...register("releaseDate")}
+              />
+              {errors.releaseDate ? (
+                <p className="text-sm text-destructive">{errors.releaseDate.message}</p>
+              ) : null}
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="episode-rating">Rating</Label>
+              <Input
+                id="episode-rating"
+                type="number"
+                min={0}
+                max={10}
+                step={0.1}
+                aria-invalid={Boolean(errors.rating)}
+                placeholder="8.5"
+                {...register("rating")}
+              />
+              {errors.rating ? (
+                <p className="text-sm text-destructive">{errors.rating.message}</p>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="episode-description">Description</Label>
+            <Textarea
+              id="episode-description"
+              aria-invalid={Boolean(errors.description)}
+              placeholder="A summary of the episode."
+              {...register("description")}
+            />
+            {errors.description ? (
+              <p className="text-sm text-destructive">{errors.description.message}</p>
+            ) : null}
+          </div>
+
+          <CredenzaFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isPending || !season}>
+              {isPending ? "Saving..." : actionLabel}
+            </Button>
+          </CredenzaFooter>
+        </form>
+      </CredenzaContent>
+    </Credenza>
+  );
+}
+
+function toDateTimeLocalValue(value?: string) {
+  if (!value) {
+    return "";
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+
+  const timezoneOffsetMs = date.getTimezoneOffset() * 60_000;
+  return new Date(date.getTime() - timezoneOffsetMs).toISOString().slice(0, 16);
+}
+
+function toIsoDateString(value: string) {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toISOString();
+}

--- a/src/hooks/useEpisodes.ts
+++ b/src/hooks/useEpisodes.ts
@@ -1,0 +1,122 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { getEpisodesRootQueryKey } from "#/hooks/useShowDetail";
+import { api } from "#/lib/api";
+import { queryClient } from "#/lib/queryClient";
+import type { Episode } from "#/types/episode";
+import type { SeasonReference } from "#/types/season";
+
+interface EpisodePayload {
+  season: SeasonReference;
+  episodeNumber: number;
+  title: string;
+  releaseDate: string;
+  description: string;
+  rating?: number;
+}
+
+interface UpdateEpisodePayload {
+  current: Episode;
+  next: {
+    episodeNumber: number;
+    title: string;
+    releaseDate: string;
+    description: string;
+    rating?: number;
+  };
+}
+
+function buildEpisodeAsset(payload: EpisodePayload) {
+  return {
+    "@assetType": "episodes",
+    season: payload.season,
+    episodeNumber: payload.episodeNumber,
+    title: payload.title,
+    releaseDate: payload.releaseDate,
+    description: payload.description,
+    ...(payload.rating !== undefined ? { rating: payload.rating } : {}),
+  };
+}
+
+function buildEpisodeKey(episode: Pick<Episode, "season" | "episodeNumber">) {
+  return {
+    "@assetType": "episodes",
+    season: episode.season,
+    episodeNumber: episode.episodeNumber,
+  };
+}
+
+async function createEpisode(payload: EpisodePayload) {
+  await api.post("/invoke/createAsset", {
+    asset: [buildEpisodeAsset(payload)],
+  });
+}
+
+async function updateEpisode({ current, next }: UpdateEpisodePayload) {
+  const episodeNumberChanged = current.episodeNumber !== next.episodeNumber;
+
+  if (episodeNumberChanged) {
+    await createEpisode({
+      season: current.season,
+      episodeNumber: next.episodeNumber,
+      title: next.title,
+      releaseDate: next.releaseDate,
+      description: next.description,
+      rating: next.rating,
+    });
+
+    await api.delete("/invoke/deleteAsset", {
+      data: {
+        key: buildEpisodeKey(current),
+      },
+    });
+
+    return;
+  }
+
+  await api.put("/invoke/updateAsset", {
+    update: buildEpisodeAsset({
+      season: current.season,
+      episodeNumber: current.episodeNumber,
+      title: next.title,
+      releaseDate: next.releaseDate,
+      description: next.description,
+      rating: next.rating,
+    }),
+  });
+}
+
+async function deleteEpisode(episode: Episode) {
+  await api.delete("/invoke/deleteAsset", {
+    data: {
+      key: buildEpisodeKey(episode),
+    },
+  });
+}
+
+async function invalidateEpisodeQueries() {
+  await queryClient.invalidateQueries({
+    queryKey: getEpisodesRootQueryKey(),
+  });
+}
+
+export function useCreateEpisode() {
+  return useMutation({
+    mutationFn: createEpisode,
+    onSuccess: invalidateEpisodeQueries,
+  });
+}
+
+export function useUpdateEpisode() {
+  return useMutation({
+    mutationFn: updateEpisode,
+    onSuccess: invalidateEpisodeQueries,
+  });
+}
+
+export function useDeleteEpisode() {
+  return useMutation({
+    mutationFn: deleteEpisode,
+    onSuccess: invalidateEpisodeQueries,
+  });
+}

--- a/src/hooks/useShowDetail.ts
+++ b/src/hooks/useShowDetail.ts
@@ -7,6 +7,7 @@ import type { SearchResponse, TvShow } from "#/types/tvShow";
 
 export const getShowDetailQueryKey = (showTitle: string) => ["show", showTitle] as const;
 export const getSeasonsQueryKey = (showKey?: string) => ["seasons", showKey] as const;
+export const getEpisodesRootQueryKey = () => ["episodes"] as const;
 export const getEpisodesQueryKey = (seasonKeys: string[]) => ["episodes", ...seasonKeys] as const;
 
 async function fetchShow(showTitle: string): Promise<TvShow> {

--- a/src/routes/_auth/shows/$showId/index.tsx
+++ b/src/routes/_auth/shows/$showId/index.tsx
@@ -1,10 +1,17 @@
 import { useMemo, useState, useSyncExternalStore, type CSSProperties } from "react";
 import { Link, Navigate, createFileRoute } from "@tanstack/react-router";
-import { Calendar03Icon, PencilEdit02Icon } from "@hugeicons/core-free-icons";
+import {
+  Calendar03Icon,
+  Delete02Icon,
+  MoreHorizontalIcon,
+  PencilEdit02Icon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
+import { DeleteEpisodeDialog } from "#/components/DeleteEpisodeDialog";
 import { DeleteSeasonDialog } from "#/components/DeleteSeasonDialog";
 import { DeleteShowDialog } from "#/components/DeleteShowDialog";
+import { EpisodeFormDialog } from "#/components/EpisodeFormDialog";
 import { SeasonFormDialog } from "#/components/SeasonFormDialog";
 import { ShowFormDialog } from "#/components/ShowFormDialog";
 import { Button } from "#/components/ui/button";
@@ -26,7 +33,6 @@ import type { TvShow } from "#/types/tvShow";
 const MOBILE_POSTER_MIN_HEIGHT_REM = 18;
 const MOBILE_POSTER_MAX_HEIGHT_REM = 27;
 const MOBILE_POSTER_SCROLL_RANGE_PX = 220;
-
 type PosterStyleVariables = CSSProperties & {
   "--mobile-poster-height": string;
   "--mobile-poster-width": string;
@@ -55,7 +61,10 @@ function ShowDetailPage() {
   const navigate = Route.useNavigate();
   const { data: allShows = [] } = useShows();
   const [creatingSeason, setCreatingSeason] = useState(false);
+  const [creatingEpisode, setCreatingEpisode] = useState(false);
+  const [deletingEpisode, setDeletingEpisode] = useState<Episode | null>(null);
   const [deletingSeason, setDeletingSeason] = useState<Season | null>(null);
+  const [editingEpisode, setEditingEpisode] = useState<Episode | null>(null);
   const [editingSeason, setEditingSeason] = useState<Season | null>(null);
   const [isEditOpen, setIsEditOpen] = useState(false);
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
@@ -212,7 +221,14 @@ function ShowDetailPage() {
                 </p>
               ) : null}
               {!isEpisodesLoading && !isEpisodesError ? (
-                <EpisodeList episodes={visibleEpisodes} season={activeSeason} showId={showId} />
+                <EpisodeList
+                  episodes={visibleEpisodes}
+                  onAddEpisode={() => setCreatingEpisode(true)}
+                  onDeleteEpisode={setDeletingEpisode}
+                  onEditEpisode={setEditingEpisode}
+                  season={activeSeason}
+                  showId={showId}
+                />
               ) : null}
             </>
           ) : null}
@@ -258,6 +274,34 @@ function ShowDetailPage() {
         open={Boolean(editingSeason)}
         season={editingSeason}
         show={showReference}
+      />
+      <EpisodeFormDialog
+        existingEpisodes={visibleEpisodes}
+        mode="create"
+        onOpenChange={setCreatingEpisode}
+        open={creatingEpisode}
+        season={activeSeason ?? null}
+      />
+      <EpisodeFormDialog
+        existingEpisodes={visibleEpisodes}
+        mode="edit"
+        onOpenChange={open => {
+          if (!open) {
+            setEditingEpisode(null);
+          }
+        }}
+        open={Boolean(editingEpisode)}
+        episode={editingEpisode}
+        season={activeSeason ?? null}
+      />
+      <DeleteEpisodeDialog
+        episode={deletingEpisode}
+        onOpenChange={open => {
+          if (!open) {
+            setDeletingEpisode(null);
+          }
+        }}
+        open={Boolean(deletingEpisode)}
       />
       <DeleteSeasonDialog
         episodes={deletingSeasonEpisodes}
@@ -431,10 +475,16 @@ function getMobilePosterHeight(scrollY: number) {
 
 function EpisodeList({
   episodes,
+  onAddEpisode,
+  onDeleteEpisode,
+  onEditEpisode,
   season,
   showId,
 }: {
   episodes: Episode[];
+  onAddEpisode: () => void;
+  onDeleteEpisode: (episode: Episode) => void;
+  onEditEpisode: (episode: Episode) => void;
   season?: Season;
   showId: string;
 }) {
@@ -449,7 +499,10 @@ function EpisodeList({
         <p className="mt-2 text-sm text-muted-foreground">
           Season {season.number} is ready for its first episode.
         </p>
-        <Button className="mt-4" disabled>
+        <Button
+          className="mt-4 h-10 w-full text-sm font-semibold md:mx-auto md:w-auto md:px-5"
+          onClick={onAddEpisode}
+        >
           Add an Episode
         </Button>
       </div>
@@ -459,18 +512,35 @@ function EpisodeList({
   return (
     <div className="flex flex-col gap-3">
       {episodes.map(episode => (
-        <EpisodeRow key={episode["@key"]} episode={episode} season={season} showId={showId} />
+        <EpisodeRow
+          key={episode["@key"]}
+          episode={episode}
+          onDelete={onDeleteEpisode}
+          onEdit={onEditEpisode}
+          season={season}
+          showId={showId}
+        />
       ))}
+      <Button
+        className="mt-2 h-10 w-full text-sm font-semibold md:mx-auto md:w-auto md:px-5"
+        onClick={onAddEpisode}
+      >
+        Add Episode
+      </Button>
     </div>
   );
 }
 
 function EpisodeRow({
   episode,
+  onDelete,
+  onEdit,
   season,
   showId,
 }: {
   episode: Episode;
+  onDelete: (episode: Episode) => void;
+  onEdit: (episode: Episode) => void;
   season: Season;
   showId: string;
 }) {
@@ -483,9 +553,37 @@ function EpisodeRow({
         showId,
         episode: `s${season.number}e${episode.episodeNumber}`,
       }}
-      className="block"
+      className="group relative block"
     >
-      <article className="grid gap-4 rounded-3xl border border-border bg-card/80 p-4 transition-colors hover:bg-card md:grid-cols-[10rem_1fr]">
+      <div className="pointer-events-none absolute right-3 top-3 z-10 hidden items-center gap-1 rounded-lg border border-border/60 bg-background/92 p-1 shadow-sm backdrop-blur opacity-0 transition-all duration-200 md:flex md:group-hover:pointer-events-auto md:group-hover:opacity-100">
+        <Button
+          size="xs"
+          variant="ghost"
+          className="text-[0.65rem] uppercase tracking-[0.12em]"
+          onClick={event => {
+            event.preventDefault();
+            event.stopPropagation();
+            onEdit(episode);
+          }}
+        >
+          <HugeiconsIcon icon={PencilEdit02Icon} className="size-3.5" />
+          <span>Edit</span>
+        </Button>
+        <Button
+          size="xs"
+          variant="destructive"
+          className="text-[0.65rem] uppercase tracking-[0.12em]"
+          onClick={event => {
+            event.preventDefault();
+            event.stopPropagation();
+            onDelete(episode);
+          }}
+        >
+          <HugeiconsIcon icon={Delete02Icon} className="size-3.5" />
+          <span>Delete</span>
+        </Button>
+      </div>
+      <article className="grid gap-4 rounded-4xl border border-border bg-card/80 p-4 transition-colors hover:bg-card md:grid-cols-[10rem_1fr]">
         <div className="relative aspect-video overflow-hidden rounded-2xl">
           {stillUrl ? (
             <img
@@ -498,6 +596,45 @@ function EpisodeRow({
             <div className={`absolute inset-0 ${getEpisodeTone(episode.title)}`} />
           )}
           <div className="absolute inset-0 bg-linear-to-t from-foreground/30 via-transparent to-transparent" />
+          <div className="absolute right-1.5 top-1.5 z-10 md:hidden">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="rounded-full border border-muted-foreground/40 bg-muted text-muted-foreground shadow-xl hover:bg-muted/90 hover:text-muted-foreground"
+                  onClick={event => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                  }}
+                >
+                  <HugeiconsIcon icon={MoreHorizontalIcon} className="size-4" />
+                  <span className="sr-only">Episode actions</span>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="min-w-32">
+                <DropdownMenuGroup>
+                  <DropdownMenuItem
+                    onSelect={event => {
+                      event.preventDefault();
+                      onEdit(episode);
+                    }}
+                  >
+                    Edit
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    variant="destructive"
+                    onSelect={event => {
+                      event.preventDefault();
+                      onDelete(episode);
+                    }}
+                  >
+                    Delete
+                  </DropdownMenuItem>
+                </DropdownMenuGroup>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
         </div>
         <div className="flex flex-col gap-2">
           <div className="flex flex-wrap items-center gap-2">

--- a/src/schemas/episode.ts
+++ b/src/schemas/episode.ts
@@ -1,0 +1,59 @@
+import { z } from "zod";
+
+import type { Episode } from "#/types/episode";
+
+function normalizeOptionalNumber(value: unknown) {
+  if (value === "" || value === null || value === undefined) {
+    return undefined;
+  }
+
+  return Number(value);
+}
+
+export function createEpisodeSchema(existingEpisodes: Episode[], currentEpisode?: Episode | null) {
+  return z
+    .object({
+      episodeNumber: z.coerce
+        .number({
+          invalid_type_error: "Episode number is required",
+        })
+        .int("Episode number must be a whole number")
+        .min(1, "Episode number must be at least 1"),
+      title: z.string().trim().min(1, "Title is required"),
+      releaseDate: z
+        .string()
+        .trim()
+        .min(1, "Release date is required")
+        .refine(value => !Number.isNaN(new Date(value).getTime()), "Release date must be valid"),
+      description: z.string().trim().min(1, "Description is required"),
+      rating: z.preprocess(
+        normalizeOptionalNumber,
+        z
+          .number({
+            invalid_type_error: "Rating must be a number",
+          })
+          .min(0, "Rating cannot be negative")
+          .max(10, "Rating cannot be greater than 10")
+          .optional(),
+      ),
+    })
+    .superRefine((value, ctx) => {
+      const duplicateEpisode = existingEpisodes.some(episode => {
+        if (currentEpisode && episode["@key"] === currentEpisode["@key"]) {
+          return false;
+        }
+
+        return episode.episodeNumber === value.episodeNumber;
+      });
+
+      if (duplicateEpisode) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["episodeNumber"],
+          message: "This season already has an episode with that number",
+        });
+      }
+    });
+}
+
+export type EpisodeFormValues = z.infer<ReturnType<typeof createEpisodeSchema>>;


### PR DESCRIPTION
## Summary
- add episode create, edit, and delete flows with shared dialogs and validation
- wire episode mutations into the show detail page with desktop and mobile action patterns
- refresh episode query data after mutations and polish the episode list CTAs

Closes #10