### PR TITLE
feat: watchlists browse and CRUD flows

### DIFF
--- a/src/components/Credenza.tsx
+++ b/src/components/Credenza.tsx
@@ -1,50 +1,69 @@
 import type { ComponentProps } from "react";
+import { Dialog as DialogPrimitive } from "radix-ui";
+import { Cancel01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 
-import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "#/components/ui/dialog";
+import { Button } from "#/components/ui/button";
 import { cn } from "#/lib/utils";
 
-function Credenza(props: ComponentProps<typeof Dialog>) {
-  return <Dialog {...props} />;
+function Credenza(props: ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="credenza" {...props} />;
 }
 
-function CredenzaTrigger(props: ComponentProps<typeof DialogTrigger>) {
-  return <DialogTrigger {...props} />;
+function CredenzaTrigger(props: ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="credenza-trigger" {...props} />;
 }
 
-function CredenzaClose(props: ComponentProps<typeof DialogClose>) {
-  return <DialogClose {...props} />;
+function CredenzaClose(props: ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="credenza-close" {...props} />;
 }
 
-function CredenzaContent({ className, ...props }: ComponentProps<typeof DialogContent>) {
+function CredenzaContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean;
+}) {
   return (
-    <DialogContent
-      className={cn(
-        "top-auto bottom-0 left-0 w-full max-w-none translate-x-0 translate-y-0 rounded-t-[2rem] rounded-b-none border-x-0 border-b-0 px-5 py-6 md:top-1/2 md:bottom-auto md:left-1/2 md:w-[min(100%-2rem,36rem)] md:max-w-[36rem] md:-translate-x-1/2 md:-translate-y-1/2 md:rounded-[2rem] md:border md:px-6 md:pt-6 md:pb-8",
-        className,
-      )}
-      {...props}
-    />
+    <DialogPrimitive.Portal>
+      <DialogPrimitive.Overlay
+        data-slot="credenza-overlay"
+        className="fixed inset-0 z-50 bg-foreground/25 backdrop-blur-sm data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0"
+      />
+      <DialogPrimitive.Content
+        data-slot="credenza-content"
+        className={cn(
+          "fixed inset-x-0 bottom-0 z-50 flex max-h-svh flex-col gap-4 overflow-y-auto rounded-t-[2rem] border border-border border-b-0 bg-card px-5 pt-6 pb-8 shadow-2xl duration-200 data-[state=closed]:animate-out data-[state=closed]:slide-out-to-bottom data-[state=open]:animate-in data-[state=open]:slide-in-from-bottom md:top-1/2 md:bottom-auto md:left-1/2 md:max-h-[calc(100vh-2rem)] md:w-[min(100%-2rem,36rem)] md:max-w-[36rem] md:-translate-x-1/2 md:-translate-y-1/2 md:rounded-[2rem] md:border md:px-6 md:pt-6 md:pb-8 md:data-[state=closed]:fade-out-0 md:data-[state=closed]:slide-out-to-bottom-0 md:data-[state=closed]:zoom-out-95 md:data-[state=open]:fade-in-0 md:data-[state=open]:slide-in-from-bottom-0 md:data-[state=open]:zoom-in-95",
+          className,
+        )}
+        {...props}
+      >
+        <div className="mx-auto h-1.5 w-14 rounded-full bg-border md:hidden" />
+        {children}
+        {showCloseButton ? (
+          <DialogPrimitive.Close asChild>
+            <Button type="button" variant="ghost" size="icon-sm" className="absolute top-4 right-4">
+              <HugeiconsIcon icon={Cancel01Icon} className="size-4" />
+              <span className="sr-only">Close</span>
+            </Button>
+          </DialogPrimitive.Close>
+        ) : null}
+      </DialogPrimitive.Content>
+    </DialogPrimitive.Portal>
   );
 }
 
-function CredenzaHeader(props: ComponentProps<"div">) {
-  return <DialogHeader {...props} />;
+function CredenzaHeader({ className, ...props }: ComponentProps<"div">) {
+  return <div className={cn("flex flex-col gap-1.5", className)} {...props} />;
 }
 
 function CredenzaFooter({ className, ...props }: ComponentProps<"div">) {
   return (
-    <DialogFooter
+    <div
       className={cn(
-        "flex-col gap-2 sm:flex-col sm:justify-start md:flex-row md:justify-end",
+        "flex flex-col gap-2 sm:flex-col sm:justify-start md:flex-row md:justify-end [&>[data-slot=button]]:h-11 [&>[data-slot=button]]:rounded-2xl [&>[data-slot=button]]:px-4 [&>[data-slot=button]]:text-sm md:[&>[data-slot=button]]:h-7 md:[&>[data-slot=button]]:rounded-md md:[&>[data-slot=button]]:px-2 md:[&>[data-slot=button]]:text-xs",
         className,
       )}
       {...props}
@@ -52,12 +71,27 @@ function CredenzaFooter({ className, ...props }: ComponentProps<"div">) {
   );
 }
 
-function CredenzaTitle(props: ComponentProps<typeof DialogTitle>) {
-  return <DialogTitle {...props} />;
+function CredenzaTitle({ className, ...props }: ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="credenza-title"
+      className={cn("display-title text-2xl font-semibold text-foreground", className)}
+      {...props}
+    />
+  );
 }
 
-function CredenzaDescription(props: ComponentProps<typeof DialogDescription>) {
-  return <DialogDescription {...props} />;
+function CredenzaDescription({
+  className,
+  ...props
+}: ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="credenza-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
 }
 
 export {

--- a/src/components/DeleteWatchlistDialog.tsx
+++ b/src/components/DeleteWatchlistDialog.tsx
@@ -1,0 +1,67 @@
+import { toast } from "sonner";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "#/components/ui/alert-dialog";
+import { useDeleteWatchlist } from "#/hooks/useWatchlists";
+import { getApiErrorMessage } from "#/lib/api-errors";
+import type { Watchlist } from "#/types/watchlist";
+
+interface DeleteWatchlistDialogProps {
+  onDeleted?: () => void;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+  watchlist: Watchlist | null;
+}
+
+export function DeleteWatchlistDialog({
+  onDeleted,
+  onOpenChange,
+  open,
+  watchlist,
+}: DeleteWatchlistDialogProps) {
+  const deleteWatchlist = useDeleteWatchlist();
+
+  async function handleDelete() {
+    if (!watchlist) {
+      return;
+    }
+
+    try {
+      await deleteWatchlist.mutateAsync(watchlist);
+      toast.success(`"${watchlist.title}" was removed successfully.`);
+      onOpenChange(false);
+      onDeleted?.();
+    } catch (error) {
+      toast.error(getApiErrorMessage(error, "Could not delete the watchlist."));
+    }
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete watchlist?</AlertDialogTitle>
+          <AlertDialogDescription>
+            {watchlist
+              ? `This will permanently remove "${watchlist.title}". This action cannot be undone.`
+              : "This will permanently remove the selected watchlist."}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={deleteWatchlist.isPending}>Cancel</AlertDialogCancel>
+          <AlertDialogAction disabled={deleteWatchlist.isPending} onClick={handleDelete}>
+            {deleteWatchlist.isPending ? "Deleting..." : "Delete Watchlist"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/ResponsiveActionMenu.tsx
+++ b/src/components/ResponsiveActionMenu.tsx
@@ -1,0 +1,119 @@
+import type { ReactNode } from "react";
+import { MoreHorizontalIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import { Button } from "#/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "#/components/ui/dropdown-menu";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "#/components/ui/sheet";
+import { cn } from "#/lib/utils";
+
+interface ResponsiveActionMenuItem {
+  destructive?: boolean;
+  icon?: ReactNode;
+  label: string;
+  onSelect: () => void;
+}
+
+interface ResponsiveActionMenuProps {
+  actions: ResponsiveActionMenuItem[];
+  className?: string;
+  description?: string;
+  title: string;
+  triggerClassName?: string;
+  triggerIconClassName?: string;
+}
+
+const defaultTriggerClassName =
+  "rounded-full border border-muted-foreground/40 bg-muted text-muted-foreground shadow-xl hover:bg-muted/90 hover:text-muted-foreground";
+
+export function ResponsiveActionMenu({
+  actions,
+  className,
+  description,
+  title,
+  triggerClassName,
+  triggerIconClassName,
+}: ResponsiveActionMenuProps) {
+  const trigger = (
+    <Button
+      size="icon"
+      variant="ghost"
+      className={cn(defaultTriggerClassName, triggerClassName)}
+      onPointerDown={event => {
+        event.stopPropagation();
+      }}
+      onClick={event => {
+        event.stopPropagation();
+      }}
+    >
+      <HugeiconsIcon icon={MoreHorizontalIcon} className={cn("size-4", triggerIconClassName)} />
+      <span className="sr-only">{title}</span>
+    </Button>
+  );
+
+  return (
+    <div className={className}>
+      <div className="md:hidden">
+        <Sheet>
+          <SheetTrigger asChild>{trigger}</SheetTrigger>
+          <SheetContent className="h-auto max-h-[min(22rem,100svh)]">
+            <SheetHeader className="pr-12">
+              <SheetTitle>{title}</SheetTitle>
+              {description ? <SheetDescription>{description}</SheetDescription> : null}
+            </SheetHeader>
+            <div className="flex flex-col gap-2">
+              {actions.map(action => (
+                <Button
+                  key={action.label}
+                  type="button"
+                  variant={action.destructive ? "destructive" : "outline"}
+                  className="h-11 justify-start gap-2 rounded-2xl px-4 text-sm"
+                  onClick={action.onSelect}
+                >
+                  {action.icon}
+                  <span>{action.label}</span>
+                </Button>
+              ))}
+            </div>
+          </SheetContent>
+        </Sheet>
+      </div>
+
+      <div className="hidden md:block">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="min-w-32">
+            <DropdownMenuGroup>
+              {actions.map(action => (
+                <DropdownMenuItem
+                  key={action.label}
+                  variant={action.destructive ? "destructive" : undefined}
+                  onSelect={event => {
+                    event.preventDefault();
+                    action.onSelect();
+                  }}
+                >
+                  {action.icon}
+                  {action.label}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
+  );
+}

--- a/src/components/WatchlistCard.tsx
+++ b/src/components/WatchlistCard.tsx
@@ -1,0 +1,252 @@
+import { Link } from "@tanstack/react-router";
+import { Delete02Icon, PencilEdit02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import { ResponsiveActionMenu } from "#/components/ResponsiveActionMenu";
+import { Card, CardContent } from "#/components/ui/card";
+import { useTMDB } from "#/hooks/useTMDB";
+import { Skeleton } from "#/components/ui/skeleton";
+import type { Watchlist } from "#/types/watchlist";
+
+interface WatchlistCardProps {
+  itemTitles?: string[];
+  onDelete: (watchlist: Watchlist) => void;
+  onEdit: (watchlist: Watchlist) => void;
+  watchlist: Watchlist;
+}
+
+export function WatchlistCard({
+  itemTitles = [],
+  onDelete,
+  onEdit,
+  watchlist,
+}: WatchlistCardProps) {
+  const showsCount = watchlist.tvShows?.length ?? 0;
+  const countLabel = showsCount === 1 ? "1 show" : `${showsCount} shows`;
+  const visibleItems = itemTitles.slice(0, 2);
+  const remainingCount = Math.max(itemTitles.length - visibleItems.length, 0);
+
+  return (
+    <Card className="group relative overflow-hidden rounded-4xl border border-border bg-card/80 pt-0 transition-shadow hover:shadow-md">
+      <div className="absolute right-3 top-3 z-10">
+        <ResponsiveActionMenu
+          title="Watchlist actions"
+          description={`Manage ${watchlist.title}`}
+          triggerClassName="size-6 rounded-full bg-background/85 opacity-100 shadow-sm backdrop-blur md:opacity-0 md:transition-opacity md:group-hover:opacity-100"
+          actions={[
+            {
+              label: "Edit",
+              onSelect: () => onEdit(watchlist),
+              icon: <HugeiconsIcon icon={PencilEdit02Icon} className="size-4" />,
+            },
+            {
+              label: "Delete",
+              onSelect: () => onDelete(watchlist),
+              destructive: true,
+              icon: <HugeiconsIcon icon={Delete02Icon} className="size-4" />,
+            },
+          ]}
+        />
+      </div>
+
+      <Link
+        to="/watchlists/$title"
+        params={{ title: encodeURIComponent(watchlist.title) }}
+        className="flex h-[22.5rem] flex-col"
+      >
+        <WatchlistArtwork itemTitles={itemTitles} title={watchlist.title} />
+        <CardContent className="flex flex-1 flex-col gap-3 p-4 pt-0">
+          <div className="-mt-10 mb-1 flex">
+            <div className="size-20 overflow-hidden rounded-3xl border border-card-foreground/12 shadow-2xl">
+              <WatchlistCover itemTitles={itemTitles} title={watchlist.title} />
+            </div>
+          </div>
+          <div className="space-y-1">
+            <h2 className="line-clamp-2 text-lg font-semibold text-foreground">
+              {watchlist.title}
+            </h2>
+            <p className="text-[0.7rem] font-semibold tracking-[0.18em] uppercase text-muted-foreground">
+              {countLabel}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {visibleItems.length > 0 ? (
+              <>
+                {visibleItems.map(title => (
+                  <span
+                    key={title}
+                    className="max-w-full rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-foreground"
+                  >
+                    <span className="block max-w-28 truncate">{title}</span>
+                  </span>
+                ))}
+                {remainingCount > 0 ? (
+                  <span className="rounded-full bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary">
+                    +{remainingCount} more
+                  </span>
+                ) : null}
+              </>
+            ) : (
+              <p className="text-sm text-muted-foreground">No shows added yet.</p>
+            )}
+          </div>
+          <p className="line-clamp-3 text-sm leading-6 text-muted-foreground">
+            {watchlist.description?.trim() || "No description yet."}
+          </p>
+        </CardContent>
+      </Link>
+    </Card>
+  );
+}
+
+function WatchlistArtwork({ itemTitles, title }: { itemTitles: string[]; title: string }) {
+  const posterTitles = itemTitles.slice(0, 4);
+  const hasMosaic = posterTitles.length >= 4;
+  const backgroundTitles = hasMosaic ? posterTitles : posterTitles.slice(0, 1);
+  const fallbackTone = getPosterFallbackTone(title);
+  const hasArtwork = backgroundTitles.length > 0;
+
+  return (
+    <div className={`relative h-28 overflow-hidden ${hasArtwork ? "bg-background" : fallbackTone}`}>
+      <div className="absolute inset-0 scale-110 blur-sm saturate-150">
+        {hasArtwork ? (
+          <WatchlistPosterGrid
+            posterTitles={backgroundTitles}
+            overflowCount={0}
+            tiled={hasMosaic}
+          />
+        ) : null}
+      </div>
+      <div className="absolute inset-0 bg-foreground/25" />
+      <div className="absolute inset-x-0 top-0 h-20 bg-linear-to-b from-background/18 to-transparent" />
+    </div>
+  );
+}
+
+function WatchlistCover({ itemTitles, title }: { itemTitles: string[]; title: string }) {
+  const posterTitles = itemTitles.slice(0, 4);
+  const hasMosaic = posterTitles.length >= 4;
+  const coverTitles = hasMosaic ? posterTitles : posterTitles.slice(0, 1);
+  const overflowCount = Math.max(itemTitles.length - 2, 0);
+
+  if (coverTitles.length === 0) {
+    return <WatchlistEmptyCover title={title} />;
+  }
+
+  return (
+    <WatchlistPosterGrid
+      posterTitles={coverTitles}
+      overflowCount={overflowCount}
+      tiled={hasMosaic}
+    />
+  );
+}
+
+function WatchlistEmptyCover({ title }: { title: string }) {
+  return (
+    <div className="flex size-full items-end bg-background/95 p-3">
+      <div className="rounded-2xl bg-muted px-3 py-2">
+        <span className="line-clamp-2 text-sm font-semibold text-foreground">{title}</span>
+      </div>
+    </div>
+  );
+}
+
+function WatchlistPosterGrid({
+  overflowCount,
+  posterTitles,
+  tiled,
+}: {
+  overflowCount: number;
+  posterTitles: string[];
+  tiled: boolean;
+}) {
+  if (!tiled) {
+    return (
+      <div className="size-full">
+        <PosterTile title={posterTitles[0]} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid size-full grid-cols-2 grid-rows-2 gap-px bg-background/35">
+      {posterTitles.map((posterTitle, index) => (
+        <PosterTile
+          key={`${posterTitle}-${index}`}
+          title={posterTitle}
+          overlayLabel={index === 3 && overflowCount > 1 ? `+${overflowCount}` : undefined}
+        />
+      ))}
+    </div>
+  );
+}
+
+function PosterTile({ overlayLabel, title }: { overlayLabel?: string; title: string }) {
+  const { imageUrl } = useTMDB(title);
+  const fallbackTone = getPosterFallbackTone(title);
+
+  return (
+    <div className={`relative size-full overflow-hidden ${fallbackTone}`}>
+      {imageUrl ? (
+        <img
+          src={imageUrl}
+          alt=""
+          aria-hidden="true"
+          className="size-full object-cover"
+          loading="lazy"
+        />
+      ) : null}
+      {overlayLabel ? (
+        <>
+          <div className="absolute inset-0 bg-foreground/65" />
+          <div className="absolute inset-0 flex items-center justify-center">
+            <span className="text-lg font-semibold text-background text-shadow-sm">
+              {overlayLabel}
+            </span>
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+function getPosterFallbackTone(title: string) {
+  const fallbackTones = [
+    "bg-gradient-to-br from-primary via-chart-3 to-chart-2",
+    "bg-gradient-to-br from-chart-4 via-primary to-secondary",
+    "bg-gradient-to-br from-chart-2 via-chart-4 to-primary",
+    "bg-gradient-to-br from-foreground via-chart-4 to-primary",
+  ];
+
+  let hash = 0;
+  for (const character of title) {
+    hash = (hash << 5) - hash + character.charCodeAt(0);
+    hash |= 0;
+  }
+
+  return fallbackTones[Math.abs(hash) % fallbackTones.length];
+}
+
+export function WatchlistCardSkeleton() {
+  return (
+    <Card className="overflow-hidden rounded-4xl border border-border bg-card/80 pt-0">
+      <div className="h-28 bg-muted/50" />
+      <CardContent className="flex flex-col gap-3 p-4 pt-0">
+        <div className="-mt-10 mb-1">
+          <Skeleton className="size-20 rounded-3xl" />
+        </div>
+        <Skeleton className="h-6 w-3/4" />
+        <Skeleton className="h-4 w-20" />
+        <div className="mt-2 flex flex-wrap gap-2">
+          <Skeleton className="h-7 w-24 rounded-full" />
+          <Skeleton className="h-7 w-20 rounded-full" />
+          <Skeleton className="h-7 w-28 rounded-full" />
+        </div>
+        <Skeleton className="mt-auto h-4 w-full" />
+        <Skeleton className="h-4 w-5/6" />
+        <Skeleton className="h-4 w-2/3" />
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/WatchlistFormDialog.tsx
+++ b/src/components/WatchlistFormDialog.tsx
@@ -1,0 +1,132 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+
+import {
+  Credenza,
+  CredenzaContent,
+  CredenzaDescription,
+  CredenzaFooter,
+  CredenzaHeader,
+  CredenzaTitle,
+} from "#/components/Credenza";
+import { Button } from "#/components/ui/button";
+import { Input } from "#/components/ui/input";
+import { Label } from "#/components/ui/label";
+import { Textarea } from "#/components/ui/textarea";
+import { useCreateWatchlist, useUpdateWatchlist } from "#/hooks/useWatchlists";
+import { getApiErrorMessage } from "#/lib/api-errors";
+import { createWatchlistSchema, type WatchlistFormValues } from "#/schemas/watchlist";
+import type { Watchlist } from "#/types/watchlist";
+
+interface WatchlistFormDialogProps {
+  existingWatchlists: Watchlist[];
+  mode: "create" | "edit";
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+  watchlist?: Watchlist | null;
+}
+
+export function WatchlistFormDialog({
+  existingWatchlists,
+  mode,
+  onOpenChange,
+  open,
+  watchlist,
+}: WatchlistFormDialogProps) {
+  const createWatchlist = useCreateWatchlist();
+  const updateWatchlist = useUpdateWatchlist();
+  const currentTitle = mode === "edit" ? watchlist?.title : undefined;
+
+  const {
+    formState: { errors },
+    handleSubmit,
+    register,
+  } = useForm<WatchlistFormValues>({
+    resolver: zodResolver(createWatchlistSchema(existingWatchlists, currentTitle)),
+    values: {
+      description: watchlist?.description ?? "",
+      title: watchlist?.title ?? "",
+    },
+  });
+
+  async function onSubmit(values: WatchlistFormValues) {
+    try {
+      if (mode === "create") {
+        await createWatchlist.mutateAsync(values);
+        toast.success(`"${values.title}" was created successfully.`);
+      } else if (watchlist) {
+        await updateWatchlist.mutateAsync({
+          current: watchlist,
+          next: values,
+        });
+        toast.success(`"${values.title}" was updated successfully.`);
+      }
+
+      onOpenChange(false);
+    } catch (error) {
+      toast.error(
+        getApiErrorMessage(
+          error,
+          mode === "create" ? "Could not create the watchlist." : "Could not update the watchlist.",
+        ),
+      );
+    }
+  }
+
+  const actionLabel = mode === "create" ? "Create Watchlist" : "Save Changes";
+  const description =
+    mode === "create"
+      ? "Create a new watchlist with a title and optional description."
+      : "Update the watchlist details without leaving the browse page.";
+  const isPending = createWatchlist.isPending || updateWatchlist.isPending;
+  const title = mode === "create" ? "New Watchlist" : "Edit Watchlist";
+
+  return (
+    <Credenza open={open} onOpenChange={onOpenChange}>
+      <CredenzaContent>
+        <CredenzaHeader>
+          <CredenzaTitle>{title}</CredenzaTitle>
+          <CredenzaDescription>{description}</CredenzaDescription>
+        </CredenzaHeader>
+
+        <form className="flex flex-col gap-5" noValidate onSubmit={handleSubmit(onSubmit)}>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="watchlist-title">Title</Label>
+            <Input
+              id="watchlist-title"
+              aria-invalid={Boolean(errors.title)}
+              placeholder="Weekend Comfort Shows"
+              {...register("title")}
+            />
+            {errors.title ? (
+              <p className="text-sm text-destructive">{errors.title.message}</p>
+            ) : null}
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="watchlist-description">Description</Label>
+            <Textarea
+              id="watchlist-description"
+              aria-invalid={Boolean(errors.description)}
+              placeholder="A quick note about what belongs in this list."
+              {...register("description")}
+            />
+            {errors.description ? (
+              <p className="text-sm text-destructive">{errors.description.message}</p>
+            ) : null}
+          </div>
+
+          <CredenzaFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button disabled={isPending} type="submit">
+              {isPending ? "Saving..." : actionLabel}
+            </Button>
+          </CredenzaFooter>
+        </form>
+      </CredenzaContent>
+    </Credenza>
+  );
+}

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -61,7 +61,13 @@ function AlertDialogHeader({ className, ...props }: React.ComponentProps<"div">)
 
 function AlertDialogFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
-    <div className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)} {...props} />
+    <div
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end [&>[data-slot=alert-dialog-action]]:h-11 [&>[data-slot=alert-dialog-action]]:rounded-2xl [&>[data-slot=alert-dialog-action]]:px-4 [&>[data-slot=alert-dialog-action]]:text-sm [&>[data-slot=alert-dialog-cancel]]:h-11 [&>[data-slot=alert-dialog-cancel]]:rounded-2xl [&>[data-slot=alert-dialog-cancel]]:px-4 [&>[data-slot=alert-dialog-cancel]]:text-sm md:[&>[data-slot=alert-dialog-action]]:h-7 md:[&>[data-slot=alert-dialog-action]]:rounded-md md:[&>[data-slot=alert-dialog-action]]:px-2 md:[&>[data-slot=alert-dialog-action]]:text-xs md:[&>[data-slot=alert-dialog-cancel]]:h-7 md:[&>[data-slot=alert-dialog-cancel]]:rounded-md md:[&>[data-slot=alert-dialog-cancel]]:px-2 md:[&>[data-slot=alert-dialog-cancel]]:text-xs",
+        className,
+      )}
+      {...props}
+    />
   );
 }
 
@@ -97,6 +103,7 @@ function AlertDialogAction({
 }: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
   return (
     <AlertDialogPrimitive.Action
+      data-slot="alert-dialog-action"
       className={cn(buttonVariants({ variant: "destructive" }), className)}
       {...props}
     />
@@ -109,6 +116,7 @@ function AlertDialogCancel({
 }: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
   return (
     <AlertDialogPrimitive.Cancel
+      data-slot="alert-dialog-cancel"
       className={cn(buttonVariants({ variant: "outline" }), className)}
       {...props}
     />

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -9,7 +9,8 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/80",
+        default:
+          "border-primary/30 bg-primary/10 text-primary hover:bg-primary/20 focus-visible:border-primary/50 focus-visible:ring-primary/20 dark:border-primary/50 dark:bg-primary/40 dark:text-chart-2 dark:hover:bg-primary/50 dark:focus-visible:ring-primary/35",
         outline:
           "border-border hover:bg-input/50 hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:bg-input/30",
         secondary:

--- a/src/hooks/useWatchlists.ts
+++ b/src/hooks/useWatchlists.ts
@@ -1,0 +1,125 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+
+import { api } from "#/lib/api";
+import { queryClient } from "#/lib/queryClient";
+import type { SearchResponse } from "#/types/tvShow";
+import type { Watchlist } from "#/types/watchlist";
+
+interface WatchlistPayload {
+  description: string;
+  title: string;
+  tvShows?: Watchlist["tvShows"];
+}
+
+interface UpdateWatchlistPayload {
+  current: Watchlist;
+  next: {
+    description: string;
+    title: string;
+  };
+}
+
+export const watchlistsQueryKey = ["watchlists"] as const;
+
+async function fetchWatchlists(): Promise<Watchlist[]> {
+  const { data } = await api.post<SearchResponse<Watchlist>>("/query/search", {
+    query: {
+      selector: {
+        "@assetType": "watchlist",
+      },
+    },
+  });
+
+  return data.result.sort((left, right) => left.title.localeCompare(right.title));
+}
+
+function buildWatchlistAsset(payload: WatchlistPayload) {
+  return {
+    "@assetType": "watchlist",
+    title: payload.title,
+    description: payload.description,
+    ...(payload.tvShows ? { tvShows: payload.tvShows } : {}),
+  };
+}
+
+async function createWatchlist(payload: WatchlistPayload) {
+  await api.post("/invoke/createAsset", {
+    asset: [buildWatchlistAsset(payload)],
+  });
+}
+
+async function updateWatchlist({ current, next }: UpdateWatchlistPayload) {
+  const titleChanged = current.title !== next.title;
+
+  if (titleChanged) {
+    await createWatchlist({
+      description: next.description,
+      title: next.title,
+      tvShows: current.tvShows,
+    });
+
+    await api.delete("/invoke/deleteAsset", {
+      data: {
+        key: {
+          "@assetType": "watchlist",
+          title: current.title,
+        },
+      },
+    });
+
+    return;
+  }
+
+  await api.put("/invoke/updateAsset", {
+    update: buildWatchlistAsset({
+      description: next.description,
+      title: current.title,
+      tvShows: current.tvShows,
+    }),
+  });
+}
+
+async function deleteWatchlist(watchlist: Watchlist) {
+  await api.delete("/invoke/deleteAsset", {
+    data: {
+      key: {
+        "@assetType": "watchlist",
+        title: watchlist.title,
+      },
+    },
+  });
+}
+
+export function useWatchlists() {
+  return useQuery({
+    queryKey: watchlistsQueryKey,
+    queryFn: fetchWatchlists,
+  });
+}
+
+export function useCreateWatchlist() {
+  return useMutation({
+    mutationFn: createWatchlist,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: watchlistsQueryKey });
+    },
+  });
+}
+
+export function useUpdateWatchlist() {
+  return useMutation({
+    mutationFn: updateWatchlist,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: watchlistsQueryKey });
+    },
+  });
+}
+
+export function useDeleteWatchlist() {
+  return useMutation({
+    mutationFn: deleteWatchlist,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: watchlistsQueryKey });
+    },
+  });
+}

--- a/src/routes/_auth/shows/$showId/index.tsx
+++ b/src/routes/_auth/shows/$showId/index.tsx
@@ -1,17 +1,13 @@
 import { useMemo, useState, useSyncExternalStore, type CSSProperties } from "react";
 import { Link, Navigate, createFileRoute } from "@tanstack/react-router";
-import {
-  Calendar03Icon,
-  Delete02Icon,
-  MoreHorizontalIcon,
-  PencilEdit02Icon,
-} from "@hugeicons/core-free-icons";
+import { Calendar03Icon, Delete02Icon, PencilEdit02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
 import { DeleteEpisodeDialog } from "#/components/DeleteEpisodeDialog";
 import { DeleteSeasonDialog } from "#/components/DeleteSeasonDialog";
 import { DeleteShowDialog } from "#/components/DeleteShowDialog";
 import { EpisodeFormDialog } from "#/components/EpisodeFormDialog";
+import { ResponsiveActionMenu } from "#/components/ResponsiveActionMenu";
 import { RouteErrorState } from "#/components/RouteErrorState";
 import { SeasonFormDialog } from "#/components/SeasonFormDialog";
 import { ShowFormDialog } from "#/components/ShowFormDialog";
@@ -636,43 +632,21 @@ function EpisodeRow({
           )}
           <div className="absolute inset-0 bg-linear-to-t from-foreground/30 via-transparent to-transparent" />
           <div className="absolute right-1.5 top-1.5 z-10 md:hidden">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  size="icon"
-                  variant="ghost"
-                  className="rounded-full border border-muted-foreground/40 bg-muted text-muted-foreground shadow-xl hover:bg-muted/90 hover:text-muted-foreground"
-                  onClick={event => {
-                    event.preventDefault();
-                    event.stopPropagation();
-                  }}
-                >
-                  <HugeiconsIcon icon={MoreHorizontalIcon} className="size-4" />
-                  <span className="sr-only">Episode actions</span>
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="min-w-32">
-                <DropdownMenuGroup>
-                  <DropdownMenuItem
-                    onSelect={event => {
-                      event.preventDefault();
-                      onEdit(episode);
-                    }}
-                  >
-                    Edit
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    variant="destructive"
-                    onSelect={event => {
-                      event.preventDefault();
-                      onDelete(episode);
-                    }}
-                  >
-                    Delete
-                  </DropdownMenuItem>
-                </DropdownMenuGroup>
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <ResponsiveActionMenu
+              title="Episode actions"
+              description={`Manage ${episode.title}`}
+              actions={[
+                {
+                  label: "Edit",
+                  onSelect: () => onEdit(episode),
+                },
+                {
+                  label: "Delete",
+                  onSelect: () => onDelete(episode),
+                  destructive: true,
+                },
+              ]}
+            />
           </div>
         </div>
         <div className="flex flex-col gap-2">

--- a/src/routes/_auth/watchlists/index.tsx
+++ b/src/routes/_auth/watchlists/index.tsx
@@ -1,14 +1,199 @@
+import { useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
+import {
+  Cancel01Icon,
+  Search01Icon,
+  SortByDown01Icon,
+  SortByUp01Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+
+import { DeleteWatchlistDialog } from "#/components/DeleteWatchlistDialog";
+import { WatchlistCard, WatchlistCardSkeleton } from "#/components/WatchlistCard";
+import { WatchlistFormDialog } from "#/components/WatchlistFormDialog";
+import { Button } from "#/components/ui/button";
+import { Input } from "#/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "#/components/ui/select";
+import { useShows } from "#/hooks/useShows";
+import { useWatchlists } from "#/hooks/useWatchlists";
+import type { Watchlist } from "#/types/watchlist";
 
 export const Route = createFileRoute("/_auth/watchlists/")({
   component: WatchlistsPage,
 });
 
+type SortOrder = "az" | "za";
+
 function WatchlistsPage() {
+  const { data: shows = [] } = useShows();
+  const { data: watchlists, isError, isLoading } = useWatchlists();
+  const [creatingWatchlist, setCreatingWatchlist] = useState(false);
+  const [editingWatchlist, setEditingWatchlist] = useState<Watchlist | null>(null);
+  const [deletingWatchlist, setDeletingWatchlist] = useState<Watchlist | null>(null);
+  const [search, setSearch] = useState("");
+  const [sort, setSort] = useState<SortOrder>("az");
+  const allWatchlists = watchlists ?? [];
+  const showTitleByKey = new Map(shows.map(show => [show["@key"], show.title]));
+  const filteredWatchlists = allWatchlists
+    .filter(watchlist => watchlist.title.toLowerCase().includes(search.toLowerCase()))
+    .sort((left, right) => {
+      if (sort === "az") {
+        return left.title.localeCompare(right.title);
+      }
+
+      return right.title.localeCompare(left.title);
+    });
+
   return (
-    <main className="mx-auto max-w-5xl px-4 py-10">
-      <h1 className="display-title text-3xl font-bold text-foreground">Watchlists</h1>
-      <p className="mt-2 text-muted-foreground">Coming in slice 11.</p>
-    </main>
+    <>
+      <main className="mx-auto w-full max-w-7xl px-4 py-10">
+        <div className="mb-6 flex items-center justify-between gap-4">
+          <div>
+            <h1 className="display-title text-3xl font-bold text-foreground">Watchlists</h1>
+            <p className="mt-2 pl-1 text-sm text-muted-foreground">
+              Organize shows into personal lists you can come back to later.
+            </p>
+          </div>
+          <Button onClick={() => setCreatingWatchlist(true)}>New Watchlist</Button>
+        </div>
+
+        <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center">
+          <div className="relative flex-1">
+            <HugeiconsIcon
+              icon={Search01Icon}
+              className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+            />
+            <Input
+              placeholder="Search watchlists..."
+              value={search}
+              onChange={event => setSearch(event.target.value)}
+              className="pl-9"
+            />
+            {search ? (
+              <button
+                type="button"
+                onClick={() => setSearch("")}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              >
+                <HugeiconsIcon icon={Cancel01Icon} className="size-4" />
+              </button>
+            ) : null}
+          </div>
+
+          <Select value={sort} onValueChange={value => setSort(value as SortOrder)}>
+            <SelectTrigger className="w-full sm:w-36">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="az">
+                <span className="flex items-center gap-2">
+                  <HugeiconsIcon icon={SortByUp01Icon} className="size-4" />
+                  Alphabetical Asc.
+                </span>
+              </SelectItem>
+              <SelectItem value="za">
+                <span className="flex items-center gap-2">
+                  <HugeiconsIcon icon={SortByDown01Icon} className="size-4" />
+                  Alphabetical Desc.
+                </span>
+              </SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        {isError ? (
+          <p className="text-sm text-destructive">Failed to load watchlists. Please try again.</p>
+        ) : null}
+
+        {isLoading ? (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {Array.from({ length: 8 }).map((_, index) => (
+              <WatchlistCardSkeleton key={index} />
+            ))}
+          </div>
+        ) : null}
+
+        {!isLoading && !isError && filteredWatchlists.length === 0 ? (
+          <div className="rounded-4xl border border-dashed border-border bg-card/50 px-6 py-16 text-center">
+            {search ? (
+              <>
+                <p className="display-title text-2xl font-semibold text-foreground">
+                  No watchlists matching "{search}"
+                </p>
+                <button
+                  type="button"
+                  onClick={() => setSearch("")}
+                  className="mt-3 text-sm text-primary underline-offset-4 hover:underline"
+                >
+                  Clear search
+                </button>
+              </>
+            ) : (
+              <>
+                <p className="display-title text-2xl font-semibold text-foreground">
+                  No watchlists yet
+                </p>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Create your first watchlist to start grouping shows by mood, genre, or anything
+                  else.
+                </p>
+                <Button className="mt-4" onClick={() => setCreatingWatchlist(true)}>
+                  Create watchlist
+                </Button>
+              </>
+            )}
+          </div>
+        ) : null}
+
+        {!isLoading && !isError && filteredWatchlists.length > 0 ? (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {filteredWatchlists.map(watchlist => (
+              <WatchlistCard
+                key={watchlist["@key"]}
+                itemTitles={(watchlist.tvShows ?? []).map(show => {
+                  return showTitleByKey.get(show["@key"]) ?? "Unknown show";
+                })}
+                watchlist={watchlist}
+                onDelete={setDeletingWatchlist}
+                onEdit={setEditingWatchlist}
+              />
+            ))}
+          </div>
+        ) : null}
+      </main>
+
+      <WatchlistFormDialog
+        existingWatchlists={allWatchlists}
+        mode="create"
+        onOpenChange={setCreatingWatchlist}
+        open={creatingWatchlist}
+      />
+      <WatchlistFormDialog
+        existingWatchlists={allWatchlists}
+        mode="edit"
+        onOpenChange={open => {
+          if (!open) {
+            setEditingWatchlist(null);
+          }
+        }}
+        open={Boolean(editingWatchlist)}
+        watchlist={editingWatchlist}
+      />
+      <DeleteWatchlistDialog
+        onOpenChange={open => {
+          if (!open) {
+            setDeletingWatchlist(null);
+          }
+        }}
+        open={Boolean(deletingWatchlist)}
+        watchlist={deletingWatchlist}
+      />
+    </>
   );
 }

--- a/src/schemas/watchlist.ts
+++ b/src/schemas/watchlist.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+import type { Watchlist } from "#/types/watchlist";
+
+export function createWatchlistSchema(existingWatchlists: Watchlist[], currentTitle?: string) {
+  return z
+    .object({
+      title: z.string().trim().min(1, "Title is required"),
+      description: z.string().trim().default(""),
+    })
+    .superRefine((value, ctx) => {
+      const normalizedTitle = value.title.toLowerCase();
+      const duplicate = existingWatchlists.some(watchlist => {
+        if (currentTitle && watchlist.title === currentTitle) {
+          return false;
+        }
+
+        return watchlist.title.toLowerCase() === normalizedTitle;
+      });
+
+      if (duplicate) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["title"],
+          message: "A watchlist with this title already exists",
+        });
+      }
+    });
+}
+
+export type WatchlistFormValues = z.infer<ReturnType<typeof createWatchlistSchema>>;

--- a/src/types/watchlist.ts
+++ b/src/types/watchlist.ts
@@ -1,0 +1,13 @@
+import type { TvShowReference } from "#/types/season";
+
+export interface Watchlist {
+  "@assetType": "watchlist";
+  "@key": string;
+  "@lastTouchBy"?: string;
+  "@lastTx"?: string;
+  "@lastTxID"?: string;
+  "@lastUpdated"?: string;
+  description?: string;
+  title: string;
+  tvShows?: TvShowReference[];
+}


### PR DESCRIPTION
Closes #12

## Summary
- add live watchlist browse and CRUD flows backed by the real `watchlist` asset type
- redesign watchlist cards with TMDB-backed artwork mosaics, show previews, search and sort controls, and dedicated empty states
- extract a reusable responsive action menu and align mobile dialogs/buttons with the newer sheet-based interaction styling

## Verification
- pnpm lint
- pnpm build