### PR TITLE
feat: watchlist detail and show membership flows

### DIFF
--- a/src/components/WatchlistFormDialog.tsx
+++ b/src/components/WatchlistFormDialog.tsx
@@ -23,6 +23,7 @@ interface WatchlistFormDialogProps {
   existingWatchlists: Watchlist[];
   mode: "create" | "edit";
   onOpenChange: (open: boolean) => void;
+  onSubmitted?: (title: string) => void;
   open: boolean;
   watchlist?: Watchlist | null;
 }
@@ -31,6 +32,7 @@ export function WatchlistFormDialog({
   existingWatchlists,
   mode,
   onOpenChange,
+  onSubmitted,
   open,
   watchlist,
 }: WatchlistFormDialogProps) {
@@ -64,6 +66,7 @@ export function WatchlistFormDialog({
       }
 
       onOpenChange(false);
+      onSubmitted?.(values.title);
     } catch (error) {
       toast.error(
         getApiErrorMessage(

--- a/src/components/WatchlistMembershipPopover.tsx
+++ b/src/components/WatchlistMembershipPopover.tsx
@@ -1,0 +1,172 @@
+import { useMemo, useState } from "react";
+import { Add01Icon, CheckmarkCircle02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { toast } from "sonner";
+
+import { WatchlistFormDialog } from "#/components/WatchlistFormDialog";
+import {
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "#/components/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "#/components/ui/popover";
+import { Button } from "#/components/ui/button";
+import { useUpdateWatchlist, useWatchlists } from "#/hooks/useWatchlists";
+import { getApiErrorMessage } from "#/lib/api-errors";
+import type { TvShowReference } from "#/types/season";
+import type { TvShow } from "#/types/tvShow";
+
+interface WatchlistMembershipPopoverProps {
+  show: TvShow | undefined;
+}
+
+export function WatchlistMembershipPopover({ show }: WatchlistMembershipPopoverProps) {
+  const { data: watchlists = [] } = useWatchlists();
+  const updateWatchlist = useUpdateWatchlist();
+  const [creatingWatchlist, setCreatingWatchlist] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const showKey = show?.["@key"];
+
+  const filteredWatchlists = useMemo(() => {
+    return watchlists.filter(watchlist =>
+      watchlist.title.toLowerCase().includes(search.trim().toLowerCase()),
+    );
+  }, [search, watchlists]);
+
+  async function toggleMembership(title: string, checked: boolean) {
+    if (!show) {
+      return;
+    }
+
+    const watchlist = watchlists.find(entry => entry.title === title);
+    if (!watchlist) {
+      return;
+    }
+
+    const currentItems = watchlist.tvShows ?? [];
+    const nextTvShows = checked
+      ? dedupeTvShows([
+          ...currentItems,
+          {
+            "@assetType": "tvShows" as const,
+            "@key": show["@key"],
+          },
+        ])
+      : currentItems.filter(reference => reference["@key"] !== show["@key"]);
+
+    try {
+      await updateWatchlist.mutateAsync({
+        current: watchlist,
+        next: {
+          title: watchlist.title,
+          description: watchlist.description ?? "",
+          tvShows: nextTvShows,
+        },
+      });
+
+      toast.success(
+        checked
+          ? `Added "${show.title}" to "${watchlist.title}".`
+          : `Removed "${show.title}" from "${watchlist.title}".`,
+      );
+    } catch (error) {
+      toast.error(getApiErrorMessage(error, "Could not update the watchlist membership."));
+    }
+  }
+
+  return (
+    <>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button disabled={!show}>+ Watchlist</Button>
+        </PopoverTrigger>
+        <PopoverContent align="end" className="mx-2 w-[22rem]">
+          <div className="flex flex-col gap-2">
+            <div className="rounded-2xl bg-popover">
+              <CommandInput
+                value={search}
+                onChange={event => setSearch(event.target.value)}
+                placeholder="Search watchlists..."
+                aria-label="Search watchlists"
+              />
+            </div>
+
+            <div className="overflow-hidden rounded-2xl bg-popover/95 ring-1 ring-border/70">
+              <CommandList className="mt-0 max-h-64 gap-0 p-1">
+                {filteredWatchlists.length === 0 ? (
+                  <CommandEmpty>No watchlists matching your search.</CommandEmpty>
+                ) : (
+                  <CommandGroup>
+                    {filteredWatchlists.map(watchlist => {
+                      const containsShow = watchlist.tvShows?.some(
+                        reference => reference["@key"] === showKey,
+                      );
+                      const isChecked = Boolean(showKey && containsShow);
+
+                      return (
+                        <CommandItem
+                          key={watchlist["@key"]}
+                          className="justify-between"
+                          onClick={() => toggleMembership(watchlist.title, !isChecked)}
+                        >
+                          <span className="min-w-0 flex-1 truncate font-medium">
+                            {watchlist.title}
+                          </span>
+                          <span
+                            className={`flex size-5 shrink-0 items-center justify-center rounded-full border ${
+                              isChecked
+                                ? "border-chart-3/60 bg-chart-3/15 text-chart-3"
+                                : "border-border bg-background text-transparent"
+                            }`}
+                          >
+                            <HugeiconsIcon icon={CheckmarkCircle02Icon} className="size-3.5" />
+                          </span>
+                        </CommandItem>
+                      );
+                    })}
+                  </CommandGroup>
+                )}
+              </CommandList>
+            </div>
+
+            <div className="rounded-2xl bg-popover/95">
+              <CommandSeparator />
+            </div>
+
+            <div className="rounded-2xl bg-popover pt-1">
+              <Button
+                type="button"
+                variant="outline"
+                className="h-11 w-full justify-start gap-2 rounded-2xl px-2 text-sm"
+                onClick={() => {
+                  setOpen(false);
+                  setCreatingWatchlist(true);
+                }}
+              >
+                <HugeiconsIcon icon={Add01Icon} className="size-4" />
+                New watchlist
+              </Button>
+            </div>
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      <WatchlistFormDialog
+        existingWatchlists={watchlists}
+        mode="create"
+        onOpenChange={setCreatingWatchlist}
+        open={creatingWatchlist}
+      />
+    </>
+  );
+}
+
+function dedupeTvShows(tvShows: TvShowReference[]) {
+  return tvShows.filter((reference, index, array) => {
+    return array.findIndex(entry => entry["@key"] === reference["@key"]) === index;
+  });
+}

--- a/src/components/WatchlistShowCard.tsx
+++ b/src/components/WatchlistShowCard.tsx
@@ -1,0 +1,83 @@
+import { Delete02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Link } from "@tanstack/react-router";
+
+import { ResponsiveActionMenu } from "#/components/ResponsiveActionMenu";
+import { Card, CardContent } from "#/components/ui/card";
+import { useTMDB } from "#/hooks/useTMDB";
+import type { TvShow } from "#/types/tvShow";
+
+interface WatchlistShowCardProps {
+  onRemove: (show: TvShow) => void;
+  show: TvShow;
+}
+
+export function WatchlistShowCard({ onRemove, show }: WatchlistShowCardProps) {
+  const showId = encodeURIComponent(show.title);
+  const { imageUrl } = useTMDB(show.title);
+  const fallbackTone = getPosterFallbackTone(show.title);
+
+  return (
+    <Card className="group relative overflow-hidden rounded-lg border border-border bg-card/80 pt-0 transition-shadow hover:shadow-md">
+      <div className="absolute right-2 top-2 z-10">
+        <ResponsiveActionMenu
+          title="Show actions"
+          description={`Manage ${show.title} in this watchlist`}
+          triggerClassName="size-7 rounded-full bg-background/88 shadow-md backdrop-blur md:opacity-0 md:transition-opacity md:group-hover:opacity-100"
+          actions={[
+            {
+              label: "Remove from watchlist",
+              onSelect: () => onRemove(show),
+              destructive: true,
+              icon: <HugeiconsIcon icon={Delete02Icon} className="size-4" />,
+            },
+          ]}
+        />
+      </div>
+
+      <Link
+        to="/shows/$showId"
+        params={{ showId }}
+        search={{ season: undefined }}
+        className="flex flex-col"
+      >
+        <div className={`relative aspect-[3/4] overflow-hidden ${fallbackTone}`}>
+          {imageUrl ? (
+            <img
+              src={imageUrl}
+              alt={`${show.title} poster`}
+              className="size-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+              loading="lazy"
+            />
+          ) : null}
+          <div className="absolute inset-0 bg-linear-to-t from-card/95 via-card/35 to-transparent" />
+          <div className="absolute inset-x-0 bottom-0 p-4">
+            <h3 className="line-clamp-2 text-base font-semibold text-shadow-md text-white">
+              {show.title}
+            </h3>
+          </div>
+        </div>
+        <CardContent className="p-4 pt-3">
+          <p className="line-clamp-3 text-sm leading-6 text-muted-foreground">{show.description}</p>
+        </CardContent>
+      </Link>
+    </Card>
+  );
+}
+
+function getPosterFallbackTone(title: string) {
+  const fallbackTones = [
+    "bg-gradient-to-br from-primary via-chart-3 to-chart-2",
+    "bg-gradient-to-br from-chart-4 via-primary to-secondary",
+    "bg-gradient-to-br from-chart-2 via-chart-4 to-primary",
+    "bg-gradient-to-br from-foreground via-chart-4 to-primary",
+  ];
+
+  let hash = 0;
+  for (const character of title) {
+    hash = (hash << 5) - hash + character.charCodeAt(0);
+    hash |= 0;
+  }
+
+  return fallbackTones[Math.abs(hash) % fallbackTones.length];
+}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,0 +1,78 @@
+import type { ComponentProps } from "react";
+
+import { cn } from "#/lib/utils";
+
+function Command({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="command"
+      className={cn("flex flex-col overflow-hidden rounded-[1.5rem] bg-transparent", className)}
+      {...props}
+    />
+  );
+}
+
+function CommandInput({ className, ...props }: ComponentProps<"input">) {
+  return (
+    <input
+      data-slot="command-input"
+      className={cn(
+        "flex h-11 w-full rounded-2xl border border-border bg-background/70 px-3 text-sm text-foreground outline-none placeholder:text-muted-foreground focus-visible:border-primary/40 focus-visible:ring-2 focus-visible:ring-primary/15",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandList({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="command-list"
+      className={cn("mt-2 flex max-h-72 flex-col gap-1 overflow-y-auto", className)}
+      {...props}
+    />
+  );
+}
+
+function CommandEmpty({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="command-empty"
+      className={cn("px-3 py-6 text-center text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function CommandGroup({ className, ...props }: ComponentProps<"div">) {
+  return <div data-slot="command-group" className={cn("flex flex-col gap-1", className)} {...props} />;
+}
+
+function CommandItem({ className, ...props }: ComponentProps<"button">) {
+  return (
+    <button
+      type="button"
+      data-slot="command-item"
+      className={cn(
+        "flex w-full items-center gap-3 rounded-2xl px-3 py-2.5 text-left text-sm text-foreground transition-colors hover:bg-foreground/6 focus-visible:bg-foreground/6 outline-none",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandSeparator({ className, ...props }: ComponentProps<"div">) {
+  return <div data-slot="command-separator" className={cn("my-1 h-px bg-border/70", className)} {...props} />;
+}
+
+export {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+};

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,36 @@
+import type { ComponentProps } from "react";
+import { Popover as PopoverPrimitive } from "radix-ui";
+
+import { cn } from "#/lib/utils";
+
+function Popover(props: ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />;
+}
+
+function PopoverTrigger(props: ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
+}
+
+function PopoverContent({
+  align = "center",
+  className,
+  sideOffset = 8,
+  ...props
+}: ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-80 rounded-3xl border border-border bg-popover/92 p-2 text-popover-foreground shadow-2xl backdrop-blur-xl backdrop-saturate-150 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          className,
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  );
+}
+
+export { Popover, PopoverContent, PopoverTrigger };

--- a/src/hooks/useWatchlists.ts
+++ b/src/hooks/useWatchlists.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 
 import { api } from "#/lib/api";
 import { queryClient } from "#/lib/queryClient";
+import type { TvShowReference } from "#/types/season";
 import type { SearchResponse } from "#/types/tvShow";
 import type { Watchlist } from "#/types/watchlist";
 
@@ -16,10 +17,12 @@ interface UpdateWatchlistPayload {
   next: {
     description: string;
     title: string;
+    tvShows?: TvShowReference[];
   };
 }
 
 export const watchlistsQueryKey = ["watchlists"] as const;
+export const getWatchlistQueryKey = (title: string) => ["watchlists", title] as const;
 
 async function fetchWatchlists(): Promise<Watchlist[]> {
   const { data } = await api.post<SearchResponse<Watchlist>>("/query/search", {
@@ -31,6 +34,17 @@ async function fetchWatchlists(): Promise<Watchlist[]> {
   });
 
   return data.result.sort((left, right) => left.title.localeCompare(right.title));
+}
+
+async function fetchWatchlist(title: string): Promise<Watchlist> {
+  const { data } = await api.post<Watchlist>("/query/readAsset", {
+    key: {
+      "@assetType": "watchlist",
+      title,
+    },
+  });
+
+  return data;
 }
 
 function buildWatchlistAsset(payload: WatchlistPayload) {
@@ -55,7 +69,7 @@ async function updateWatchlist({ current, next }: UpdateWatchlistPayload) {
     await createWatchlist({
       description: next.description,
       title: next.title,
-      tvShows: current.tvShows,
+      tvShows: next.tvShows ?? current.tvShows,
     });
 
     await api.delete("/invoke/deleteAsset", {
@@ -74,7 +88,7 @@ async function updateWatchlist({ current, next }: UpdateWatchlistPayload) {
     update: buildWatchlistAsset({
       description: next.description,
       title: current.title,
-      tvShows: current.tvShows,
+      tvShows: next.tvShows ?? current.tvShows,
     }),
   });
 }
@@ -97,6 +111,14 @@ export function useWatchlists() {
   });
 }
 
+export function useWatchlist(title: string) {
+  return useQuery({
+    queryKey: getWatchlistQueryKey(title),
+    enabled: Boolean(title),
+    queryFn: () => fetchWatchlist(title),
+  });
+}
+
 export function useCreateWatchlist() {
   return useMutation({
     mutationFn: createWatchlist,
@@ -109,8 +131,18 @@ export function useCreateWatchlist() {
 export function useUpdateWatchlist() {
   return useMutation({
     mutationFn: updateWatchlist,
-    onSuccess: async () => {
+    onSuccess: async (_data, variables) => {
       await queryClient.invalidateQueries({ queryKey: watchlistsQueryKey });
+      await queryClient.invalidateQueries({
+        queryKey: getWatchlistQueryKey(variables.current.title),
+      });
+
+      const nextTitle = variables.next.title;
+      if (nextTitle && nextTitle !== variables.current.title) {
+        await queryClient.invalidateQueries({
+          queryKey: getWatchlistQueryKey(nextTitle),
+        });
+      }
     },
   });
 }

--- a/src/routes/_auth/shows/$showId/episodes/$episode.tsx
+++ b/src/routes/_auth/shows/$showId/episodes/$episode.tsx
@@ -589,13 +589,11 @@ function getEpisodeTone(seed: string) {
 }
 
 function getHistorySnapshot(entry: EpisodeHistoryEntry) {
-  const snapshot = { ...entry };
-
-  delete snapshot._isDelete;
-  delete snapshot._timestamp;
-  delete snapshot._txId;
-
-  return snapshot;
+  return Object.fromEntries(
+    Object.entries(entry).filter(([key]) => {
+      return key !== "_isDelete" && key !== "_timestamp" && key !== "_txId";
+    }),
+  );
 }
 
 function getFlattenedEpisodeNumber({

--- a/src/routes/_auth/shows/$showId/index.tsx
+++ b/src/routes/_auth/shows/$showId/index.tsx
@@ -11,6 +11,7 @@ import { ResponsiveActionMenu } from "#/components/ResponsiveActionMenu";
 import { RouteErrorState } from "#/components/RouteErrorState";
 import { SeasonFormDialog } from "#/components/SeasonFormDialog";
 import { ShowFormDialog } from "#/components/ShowFormDialog";
+import { WatchlistMembershipPopover } from "#/components/WatchlistMembershipPopover";
 import { Button } from "#/components/ui/button";
 import {
   DropdownMenu,
@@ -450,9 +451,7 @@ function ShowHero({
           <Button variant="secondary" onClick={onDelete} disabled={!show}>
             Delete Show
           </Button>
-          <Button variant="outline" disabled>
-            + Watchlist
-          </Button>
+          <WatchlistMembershipPopover show={show} />
         </div>
       </div>
     </section>

--- a/src/routes/_auth/watchlists/$title.tsx
+++ b/src/routes/_auth/watchlists/$title.tsx
@@ -1,15 +1,170 @@
+import { useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
+import { toast } from "sonner";
+
+import { DeleteWatchlistDialog } from "#/components/DeleteWatchlistDialog";
+import { RouteErrorState } from "#/components/RouteErrorState";
+import { WatchlistFormDialog } from "#/components/WatchlistFormDialog";
+import { WatchlistShowCard } from "#/components/WatchlistShowCard";
+import { Button } from "#/components/ui/button";
+import { useShows } from "#/hooks/useShows";
+import { useUpdateWatchlist, useWatchlist, useWatchlists } from "#/hooks/useWatchlists";
+import { getApiErrorMessage } from "#/lib/api-errors";
+import type { TvShow } from "#/types/tvShow";
 
 export const Route = createFileRoute("/_auth/watchlists/$title")({
+  loader: ({ params }) => ({
+    crumb: decodeURIComponent(params.title),
+  }),
   component: WatchlistDetailPage,
 });
 
 function WatchlistDetailPage() {
   const { title } = Route.useParams();
+  const decodedTitle = decodeURIComponent(title);
+  const navigate = Route.useNavigate();
+  const { data: allWatchlists = [] } = useWatchlists();
+  const { data: watchlist, isError, isLoading } = useWatchlist(decodedTitle);
+  const { data: shows = [] } = useShows();
+  const updateWatchlist = useUpdateWatchlist();
+  const [editingWatchlist, setEditingWatchlist] = useState(false);
+  const [deletingWatchlist, setDeletingWatchlist] = useState(false);
+
+  const showMap = new Map(shows.map(show => [show["@key"], show]));
+  const watchlistShows = (watchlist?.tvShows ?? [])
+    .map(reference => showMap.get(reference["@key"]))
+    .filter((show): show is TvShow => Boolean(show));
+  const countLabel =
+    watchlistShows.length === 1
+      ? "1 show in this watchlist"
+      : `${watchlistShows.length} shows in this watchlist`;
+
+  async function removeShow(show: TvShow) {
+    if (!watchlist) {
+      return;
+    }
+
+    try {
+      await updateWatchlist.mutateAsync({
+        current: watchlist,
+        next: {
+          title: watchlist.title,
+          description: watchlist.description ?? "",
+          tvShows: (watchlist.tvShows ?? []).filter(
+            reference => reference["@key"] !== show["@key"],
+          ),
+        },
+      });
+
+      toast.success(`Removed "${show.title}" from "${watchlist.title}".`);
+    } catch (error) {
+      toast.error(getApiErrorMessage(error, "Could not remove the show from this watchlist."));
+    }
+  }
+
+  if (!isLoading && isError) {
+    return (
+      <RouteErrorState
+        actionLabel="Back to watchlists"
+        description="This watchlist doesn't exist or may have been removed."
+        onAction={() =>
+          navigate({
+            to: "/watchlists",
+          })
+        }
+        title="Watchlist not found"
+      />
+    );
+  }
+
   return (
-    <main className="mx-auto max-w-5xl px-4 py-10">
-      <h1 className="display-title text-3xl font-bold text-foreground">{title}</h1>
-      <p className="mt-2 text-muted-foreground">Coming in slice 12.</p>
-    </main>
+    <>
+      <main className="mx-auto w-full max-w-7xl px-4 py-10">
+        <div className="flex flex-col gap-6">
+          <section className="rounded-[2rem] border border-border bg-card/70 px-6 py-8 shadow-sm">
+            <div className="flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
+              <div className="space-y-3">
+                <p className="text-xs font-semibold tracking-[0.24em] uppercase text-muted-foreground">
+                  Watchlist Detail
+                </p>
+                <h1 className="display-title text-4xl font-bold text-foreground md:text-5xl">
+                  {isLoading ? "Loading..." : (watchlist?.title ?? decodedTitle)}
+                </h1>
+                {!isLoading ? (
+                  <p className="text-xs font-semibold tracking-[0.2em] uppercase text-muted-foreground">
+                    {countLabel}
+                  </p>
+                ) : null}
+                <p className="max-w-2xl text-sm leading-7 text-muted-foreground md:text-base">
+                  {watchlist?.description?.trim() || "No description for this watchlist yet."}
+                </p>
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  variant="secondary"
+                  onClick={() => setEditingWatchlist(true)}
+                  disabled={!watchlist}
+                >
+                  Edit Watchlist
+                </Button>
+                <Button
+                  variant="secondary"
+                  onClick={() => setDeletingWatchlist(true)}
+                  disabled={!watchlist}
+                >
+                  Delete Watchlist
+                </Button>
+              </div>
+            </div>
+          </section>
+
+          {isLoading ? <p className="text-sm text-muted-foreground">Loading watchlist...</p> : null}
+
+          {!isLoading && watchlist && watchlistShows.length === 0 ? (
+            <div className="rounded-4xl border border-dashed border-border bg-card/50 px-6 py-16 text-center">
+              <p className="display-title text-2xl font-semibold text-foreground">No shows yet</p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Add shows from the show detail page to start building this watchlist.
+              </p>
+            </div>
+          ) : null}
+
+          {!isLoading && watchlistShows.length > 0 ? (
+            <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+              {watchlistShows.map(show => (
+                <WatchlistShowCard key={show["@key"]} show={show} onRemove={removeShow} />
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </main>
+
+      <WatchlistFormDialog
+        existingWatchlists={allWatchlists}
+        mode="edit"
+        onOpenChange={setEditingWatchlist}
+        onSubmitted={nextTitle => {
+          navigate({
+            to: "/watchlists/$title",
+            params: { title: encodeURIComponent(nextTitle) },
+            replace: true,
+          });
+        }}
+        open={editingWatchlist}
+        watchlist={watchlist ?? null}
+      />
+
+      <DeleteWatchlistDialog
+        onDeleted={() =>
+          navigate({
+            to: "/watchlists",
+          })
+        }
+        onOpenChange={setDeletingWatchlist}
+        open={deletingWatchlist}
+        watchlist={watchlist ?? null}
+      />
+    </>
   );
 }


### PR DESCRIPTION
Closes #13

## Summary
- add the watchlist detail route with live loading, header actions, empty state, and removable show cards
- extend the watchlist data layer with a single-watchlist query and membership-aware updates that invalidate both browse and detail caches
- add the searchable `+ Watchlist` picker on the show detail hero using new popover and command primitives

## Verification
- pnpm lint
- pnpm build