### PR TITLE
chore: prevent season tab action label wrapping on mobile

### DIFF
--- a/src/routes/_auth/shows/$showId/index.tsx
+++ b/src/routes/_auth/shows/$showId/index.tsx
@@ -197,7 +197,7 @@ function ShowDetailPage() {
                             resetScroll: false,
                           })
                         }
-                        className="h-full min-w-0 flex-1 rounded-full px-3 py-2 text-sm font-medium text-shadow-md"
+                        className="h-full min-w-0 truncate flex-1 rounded-full px-3 py-2 text-sm font-medium text-shadow-md"
                       >
                         Season {season.number}
                       </button>
@@ -213,7 +213,7 @@ function ShowDetailPage() {
                             }`}
                           >
                             <HugeiconsIcon icon={PencilEdit02Icon} className="size-3.5" />
-                            <span>Edit</span>
+                            <span className="min-w-0">Edit</span>
                             <span className="sr-only">Season actions</span>
                           </Button>
                         </DropdownMenuTrigger>


### PR DESCRIPTION
## Summary
- prevent the season tab action label from wrapping on mobile when tab width gets tight
- keep the Edit action readable without disturbing the existing desktop behavior

## Verification
- pnpm lint