### PR TITLE
feat: polished empty states across entity pages

### DIFF
--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from "react";
+
+import { cn } from "#/lib/utils";
+
+interface EmptyStateProps {
+  action?: ReactNode;
+  className?: string;
+  description: string;
+  icon: ReactNode;
+  title: string;
+}
+
+export function EmptyState({ action, className, description, icon, title }: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-4xl border border-dashed border-border bg-card/50 px-6 py-14 text-center",
+        className,
+      )}
+    >
+      <div className="mx-auto flex size-14 items-center justify-center rounded-3xl border border-border bg-background/85 shadow-sm">
+        <div className="text-muted-foreground">{icon}</div>
+      </div>
+      <h2 className="display-title mt-5 text-2xl font-semibold text-foreground">{title}</h2>
+      <p className="mx-auto mt-2 max-w-md text-sm leading-6 text-muted-foreground">{description}</p>
+      {action ? <div className="mt-5 flex justify-center">{action}</div> : null}
+    </div>
+  );
+}

--- a/src/routes/_auth/shows/$showId/index.tsx
+++ b/src/routes/_auth/shows/$showId/index.tsx
@@ -1,11 +1,17 @@
 import { useMemo, useState, useSyncExternalStore, type CSSProperties } from "react";
 import { Link, Navigate, createFileRoute } from "@tanstack/react-router";
-import { Calendar03Icon, Delete02Icon, PencilEdit02Icon } from "@hugeicons/core-free-icons";
+import {
+  Calendar03Icon,
+  Delete02Icon,
+  PencilEdit02Icon,
+  Tv01Icon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
 import { DeleteEpisodeDialog } from "#/components/DeleteEpisodeDialog";
 import { DeleteSeasonDialog } from "#/components/DeleteSeasonDialog";
 import { DeleteShowDialog } from "#/components/DeleteShowDialog";
+import { EmptyState } from "#/components/EmptyState";
 import { EpisodeFormDialog } from "#/components/EpisodeFormDialog";
 import { ResponsiveActionMenu } from "#/components/ResponsiveActionMenu";
 import { RouteErrorState } from "#/components/RouteErrorState";
@@ -516,18 +522,20 @@ function EpisodeList({
 
   if (episodes.length === 0) {
     return (
-      <div className="rounded-3xl border border-dashed border-border bg-card/50 px-6 py-12 text-center">
-        <p className="display-title text-2xl font-semibold text-foreground">No episodes yet</p>
-        <p className="mt-2 text-sm text-muted-foreground">
-          Season {season.number} is ready for its first episode.
-        </p>
-        <Button
-          className="mt-4 h-10 w-full text-sm font-semibold md:mx-auto md:w-auto md:px-5"
-          onClick={onAddEpisode}
-        >
-          Add an Episode
-        </Button>
-      </div>
+      <EmptyState
+        icon={<HugeiconsIcon icon={Calendar03Icon} className="size-6" />}
+        title="No episodes yet"
+        description={`Season ${season.number} is ready for its first episode.`}
+        action={
+          <Button
+            className="h-10 w-full text-sm font-semibold md:w-auto md:px-5"
+            onClick={onAddEpisode}
+          >
+            Add an Episode
+          </Button>
+        }
+        className="rounded-3xl py-12"
+      />
     );
   }
 
@@ -709,13 +717,17 @@ function EmptySeasonState({
   onAddSeason: () => void;
 }) {
   return (
-    <div className="rounded-3xl border border-dashed border-border bg-card/50 px-6 py-12 text-center">
-      <p className="display-title text-2xl font-semibold text-foreground">No seasons yet</p>
-      <p className="mt-2 text-sm text-muted-foreground">This show is ready for its first season.</p>
-      <Button className="mt-4" disabled={disabled} onClick={onAddSeason}>
-        Add a Season
-      </Button>
-    </div>
+    <EmptyState
+      icon={<HugeiconsIcon icon={Tv01Icon} className="size-6" />}
+      title="No seasons yet"
+      description="This show is ready for its first season."
+      action={
+        <Button disabled={disabled} onClick={onAddSeason}>
+          Add a Season
+        </Button>
+      }
+      className="rounded-3xl py-12"
+    />
   );
 }
 

--- a/src/routes/_auth/shows/index.tsx
+++ b/src/routes/_auth/shows/index.tsx
@@ -5,9 +5,11 @@ import {
   Search01Icon,
   SortByDown01Icon,
   SortByUp01Icon,
+  Tv01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { DeleteShowDialog } from "#/components/DeleteShowDialog";
+import { EmptyState } from "#/components/EmptyState";
 import { ShowFormDialog } from "#/components/ShowFormDialog";
 import { ShowCard, ShowCardSkeleton } from "#/components/ShowCard";
 import { Button } from "#/components/ui/button";
@@ -108,19 +110,29 @@ function ShowsPage() {
       )}
 
       {!isLoading && !isError && filtered.length === 0 && (
-        <div className="py-20 text-center">
+        <div className="py-8">
           {search ? (
-            <>
-              <p className="text-muted-foreground">No shows matching &ldquo;{search}&rdquo;</p>
-              <button
-                onClick={() => setSearch("")}
-                className="mt-2 text-sm text-primary underline-offset-4 hover:underline"
-              >
-                Clear search
-              </button>
-            </>
+            <EmptyState
+              icon={<HugeiconsIcon icon={Search01Icon} className="size-6" />}
+              title={`No shows matching "${search}"`}
+              description="Try a different title or clear the current search to see your full catalogue again."
+              action={
+                <button
+                  type="button"
+                  onClick={() => setSearch("")}
+                  className="text-sm font-medium text-primary underline-offset-4 hover:underline"
+                >
+                  Clear search
+                </button>
+              }
+            />
           ) : (
-            <p className="text-muted-foreground">No shows yet.</p>
+            <EmptyState
+              icon={<HugeiconsIcon icon={Tv01Icon} className="size-6" />}
+              title="No shows yet"
+              description="Add your first show to start building your catalogue and unlock seasons, episodes, and watchlists."
+              action={<Button onClick={() => setIsCreateOpen(true)}>Add your first show</Button>}
+            />
           )}
         </div>
       )}

--- a/src/routes/_auth/watchlists/$title.tsx
+++ b/src/routes/_auth/watchlists/$title.tsx
@@ -1,8 +1,11 @@
 import { useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
+import { Bookmark01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { toast } from "sonner";
 
 import { DeleteWatchlistDialog } from "#/components/DeleteWatchlistDialog";
+import { EmptyState } from "#/components/EmptyState";
 import { RouteErrorState } from "#/components/RouteErrorState";
 import { WatchlistFormDialog } from "#/components/WatchlistFormDialog";
 import { WatchlistShowCard } from "#/components/WatchlistShowCard";
@@ -122,12 +125,11 @@ function WatchlistDetailPage() {
           {isLoading ? <p className="text-sm text-muted-foreground">Loading watchlist...</p> : null}
 
           {!isLoading && watchlist && watchlistShows.length === 0 ? (
-            <div className="rounded-4xl border border-dashed border-border bg-card/50 px-6 py-16 text-center">
-              <p className="display-title text-2xl font-semibold text-foreground">No shows yet</p>
-              <p className="mt-2 text-sm text-muted-foreground">
-                Add shows from the show detail page to start building this watchlist.
-              </p>
-            </div>
+            <EmptyState
+              icon={<HugeiconsIcon icon={Bookmark01Icon} className="size-6" />}
+              title="No shows yet"
+              description="Add shows from the browse page or from a show detail view to start building this watchlist."
+            />
           ) : null}
 
           {!isLoading && watchlistShows.length > 0 ? (

--- a/src/routes/_auth/watchlists/index.tsx
+++ b/src/routes/_auth/watchlists/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import {
+  Bookmark01Icon,
   Cancel01Icon,
   Search01Icon,
   SortByDown01Icon,
@@ -9,6 +10,7 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 
 import { DeleteWatchlistDialog } from "#/components/DeleteWatchlistDialog";
+import { EmptyState } from "#/components/EmptyState";
 import { WatchlistCard, WatchlistCardSkeleton } from "#/components/WatchlistCard";
 import { WatchlistFormDialog } from "#/components/WatchlistFormDialog";
 import { Button } from "#/components/ui/button";
@@ -120,33 +122,31 @@ function WatchlistsPage() {
         ) : null}
 
         {!isLoading && !isError && filteredWatchlists.length === 0 ? (
-          <div className="rounded-4xl border border-dashed border-border bg-card/50 px-6 py-16 text-center">
+          <div className="py-2">
             {search ? (
-              <>
-                <p className="display-title text-2xl font-semibold text-foreground">
-                  No watchlists matching "{search}"
-                </p>
-                <button
-                  type="button"
-                  onClick={() => setSearch("")}
-                  className="mt-3 text-sm text-primary underline-offset-4 hover:underline"
-                >
-                  Clear search
-                </button>
-              </>
+              <EmptyState
+                icon={<HugeiconsIcon icon={Search01Icon} className="size-6" />}
+                title={`No watchlists matching "${search}"`}
+                description="Try a different name or clear the search to bring your saved collections back into view."
+                action={
+                  <button
+                    type="button"
+                    onClick={() => setSearch("")}
+                    className="text-sm font-medium text-primary underline-offset-4 hover:underline"
+                  >
+                    Clear search
+                  </button>
+                }
+              />
             ) : (
-              <>
-                <p className="display-title text-2xl font-semibold text-foreground">
-                  No watchlists yet
-                </p>
-                <p className="mt-2 text-sm text-muted-foreground">
-                  Create your first watchlist to start grouping shows by mood, genre, or anything
-                  else.
-                </p>
-                <Button className="mt-4" onClick={() => setCreatingWatchlist(true)}>
-                  Create watchlist
-                </Button>
-              </>
+              <EmptyState
+                icon={<HugeiconsIcon icon={Bookmark01Icon} className="size-6" />}
+                title="No watchlists yet"
+                description="Create your first watchlist to start grouping shows by mood, genre, weekend plans, or anything else."
+                action={
+                  <Button onClick={() => setCreatingWatchlist(true)}>Create watchlist</Button>
+                }
+              />
             )}
           </div>
         ) : null}


### PR DESCRIPTION
Closes #15

## Summary
- add a reusable EmptyState component with configurable icon, copy, and optional action slot
- apply the shared empty-state treatment to shows browse, watchlists browse, show detail season and episode gaps, and empty watchlist detail
- upgrade search no-results flows to use the same pattern while keeping Clear search as the only action

## Verification
- pnpm lint
- pnpm build