### PR TITLE
feat: improve visual feedback on login and watchlist interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Criei duas camadas de acesso às credenciais. A primeira é `lib/auth.ts`, com f
 
 O interceptor do Axios lê o cookie em cada requisição e injeta o header `Authorization`. Na resposta, um segundo interceptor captura status `401`, limpa o cookie e redireciona para `/login`. Erros de rede disparam um toast genérico.
 
+Para validar as credenciais antes de armazená-las, o formulário de login usa o endpoint `GET /query/getHeader` como probe de autenticação. A chamada é feita com raw Axios fora do cliente configurado, para que os interceptors globais não interfiram no fluxo de login. Se a resposta for bem-sucedida, as credenciais são gravadas no cookie e o usuário é redirecionado. Se der 401, o hook expõe `isError` e o formulário exibe a mensagem de erro sem disparar toasts globais.
+
 Em produção, a solução seria diferente: um BFF configuraria o cookie como `HttpOnly` para eliminar a exposição ao JavaScript, e o fluxo de autenticação incluiria refresh tokens para evitar que o usuário precise fazer login novamente a cada expiração de sessão.
 
 ### Sem geração de código (Orval)

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 set -e
 
-sed -i "s|__VITE_API_BASE_URL__|${VITE_API_BASE_URL}|g" /usr/share/nginx/html/env-config.js
-sed -i "s|__VITE_TMDB_API_KEY__|${VITE_TMDB_API_KEY}|g" /usr/share/nginx/html/env-config.js
+cat > /usr/share/nginx/html/env-config.js <<EOF
+window.__ENV__ = {
+  VITE_API_BASE_URL: "${VITE_API_BASE_URL}",
+  VITE_TMDB_API_KEY: "${VITE_TMDB_API_KEY}"
+};
+EOF
 
 exec "$@"

--- a/public/env-config.js
+++ b/public/env-config.js
@@ -1,4 +1,1 @@
-window.__ENV__ = {
-  VITE_API_BASE_URL: "__VITE_API_BASE_URL__",
-  VITE_TMDB_API_KEY: "__VITE_TMDB_API_KEY__",
-};
+window.__ENV__ = {};

--- a/src/components/WatchlistMembershipPopover.tsx
+++ b/src/components/WatchlistMembershipPopover.tsx
@@ -29,6 +29,7 @@ export function WatchlistMembershipPopover({ show }: WatchlistMembershipPopoverP
   const [creatingWatchlist, setCreatingWatchlist] = useState(false);
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
+  const [pendingTitle, setPendingTitle] = useState<string | null>(null);
   const showKey = show?.["@key"];
 
   const filteredWatchlists = useMemo(() => {
@@ -58,6 +59,7 @@ export function WatchlistMembershipPopover({ show }: WatchlistMembershipPopoverP
         ])
       : currentItems.filter(reference => reference["@key"] !== show["@key"]);
 
+    setPendingTitle(title);
     try {
       await updateWatchlist.mutateAsync({
         current: watchlist,
@@ -75,6 +77,8 @@ export function WatchlistMembershipPopover({ show }: WatchlistMembershipPopoverP
       );
     } catch (error) {
       toast.error(getApiErrorMessage(error, "Could not update the watchlist membership."));
+    } finally {
+      setPendingTitle(null);
     }
   }
 
@@ -111,6 +115,7 @@ export function WatchlistMembershipPopover({ show }: WatchlistMembershipPopoverP
                         <CommandItem
                           key={watchlist["@key"]}
                           className="justify-between"
+                          disabled={pendingTitle === watchlist.title}
                           onClick={() => toggleMembership(watchlist.title, !isChecked)}
                         >
                           <span className="min-w-0 flex-1 truncate font-medium">
@@ -118,12 +123,37 @@ export function WatchlistMembershipPopover({ show }: WatchlistMembershipPopoverP
                           </span>
                           <span
                             className={`flex size-5 shrink-0 items-center justify-center rounded-full border ${
-                              isChecked
-                                ? "border-chart-3/60 bg-chart-3/15 text-chart-3"
-                                : "border-border bg-background text-transparent"
+                              pendingTitle === watchlist.title
+                                ? "border-muted-foreground/40 bg-muted/20 text-muted-foreground"
+                                : isChecked
+                                  ? "border-chart-3/60 bg-chart-3/15 text-chart-3"
+                                  : "border-border bg-background text-transparent"
                             }`}
                           >
-                            <HugeiconsIcon icon={CheckmarkCircle02Icon} className="size-3.5" />
+                            {pendingTitle === watchlist.title ? (
+                              <svg
+                                className="size-3.5 animate-spin"
+                                xmlns="http://www.w3.org/2000/svg"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                              >
+                                <circle
+                                  className="opacity-25"
+                                  cx="12"
+                                  cy="12"
+                                  r="10"
+                                  stroke="currentColor"
+                                  strokeWidth="4"
+                                />
+                                <path
+                                  className="opacity-75"
+                                  fill="currentColor"
+                                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                                />
+                              </svg>
+                            ) : (
+                              <HugeiconsIcon icon={CheckmarkCircle02Icon} className="size-3.5" />
+                            )}
                           </span>
                         </CommandItem>
                       );

--- a/src/hooks/useLogin.test.tsx
+++ b/src/hooks/useLogin.test.tsx
@@ -1,0 +1,65 @@
+import type { ReactNode } from "react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import axios from "axios";
+import { vi } from "vitest";
+
+import { useLogin } from "#/hooks/useLogin";
+import { setCredentials } from "#/lib/auth";
+import { createTestQueryClient } from "#/test/test-utils";
+
+const navigateMock = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock("axios");
+
+vi.mock("#/lib/auth", () => ({
+  setCredentials: vi.fn(),
+}));
+
+vi.mock("#/lib/env", () => ({
+  getEnv: () => "http://test-api",
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={createTestQueryClient()}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useLogin", () => {
+  it("sets credentials and navigates on successful API response", async () => {
+    vi.mocked(axios.get).mockResolvedValueOnce({ data: {} });
+
+    const { result } = renderHook(() => useLogin(), { wrapper });
+
+    result.current.login({ username: "user", password: "pass" });
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(axios.get).toHaveBeenCalledWith(
+      "http://test-api/query/getHeader",
+      expect.objectContaining({
+        headers: { Authorization: `Basic ${btoa("user:pass")}` },
+      }),
+    );
+    expect(setCredentials).toHaveBeenCalledWith("user", "pass");
+    expect(navigateMock).toHaveBeenCalledWith({ to: "/" });
+  });
+
+  it("exposes isError and does not set credentials on a failed API response", async () => {
+    vi.mocked(axios.get).mockRejectedValueOnce(new Error("Unauthorized"));
+
+    const { result } = renderHook(() => useLogin(), { wrapper });
+
+    result.current.login({ username: "user", password: "wrong" });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(setCredentials).not.toHaveBeenCalled();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -1,0 +1,29 @@
+import { useMutation } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import axios from "axios";
+import { setCredentials } from "#/lib/auth";
+import { getEnv } from "#/lib/env";
+import type { LoginFormValues } from "#/schemas/auth";
+
+async function verifyCredentials(username: string, password: string) {
+  await axios.get(`${getEnv("VITE_API_BASE_URL")}/query/getHeader`, {
+    headers: {
+      Authorization: `Basic ${btoa(`${username}:${password}`)}`,
+    },
+  });
+}
+
+export function useLogin() {
+  const navigate = useNavigate();
+
+  const { mutate: login, isPending, isError } = useMutation({
+    mutationFn: ({ username, password }: LoginFormValues) =>
+      verifyCredentials(username, password),
+    onSuccess: (_, { username, password }) => {
+      setCredentials(username, password);
+      navigate({ to: "/" });
+    },
+  });
+
+  return { login, isPending, isError };
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -6,5 +6,5 @@ declare global {
 
 export function getEnv(key: string): string {
   const runtime = typeof window !== "undefined" ? window.__ENV__?.[key] : undefined;
-  return runtime ?? (import.meta.env[key] as string | undefined) ?? "";
+  return runtime || (import.meta.env[key] as string | undefined) || "";
 }

--- a/src/pages/_auth/shows/ShowDetailPage.tsx
+++ b/src/pages/_auth/shows/ShowDetailPage.tsx
@@ -577,7 +577,7 @@ function ShowHero({
           ) : null}
         </div>
 
-        <div className="flex flex-wrap gap-2 md:ml-auto md:self-end">
+        <div className="flex flex-wrap gap-2 md:ml-auto md:flex-nowrap md:self-end">
           <Button variant="secondary" onClick={onEdit} disabled={!show}>
             Edit Show
           </Button>

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -2,7 +2,8 @@ import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { loginSchema, type LoginFormValues } from "#/schemas/auth";
-import { isAuthenticated, setCredentials } from "#/lib/auth";
+import { isAuthenticated } from "#/lib/auth";
+import { useLogin } from "#/hooks/useLogin";
 import { Button } from "#/components/ui/button";
 import { Input } from "#/components/ui/input";
 import { Label } from "#/components/ui/label";
@@ -17,7 +18,7 @@ export const Route = createFileRoute("/login")({
 });
 
 function LoginPage() {
-  const navigate = useNavigate();
+  const { login, isPending, isError } = useLogin();
 
   const {
     register,
@@ -27,11 +28,6 @@ function LoginPage() {
     resolver: zodResolver(loginSchema),
     defaultValues: { username: "", password: "" },
   });
-
-  function onSubmit(values: LoginFormValues) {
-    setCredentials(values.username, values.password);
-    navigate({ to: "/" });
-  }
 
   return (
     <div className="flex min-h-svh flex-col items-center justify-center px-4">
@@ -44,13 +40,14 @@ function LoginPage() {
           <p className="mt-1.5 text-sm text-muted-foreground">Sign in to access the catalogue</p>
         </div>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-5" noValidate>
+        <form onSubmit={handleSubmit(values => login(values))} className="space-y-5" noValidate>
           <div className="space-y-1.5">
             <Label htmlFor="username">Username</Label>
             <Input
               id="username"
               autoComplete="username"
               aria-invalid={!!errors.username}
+              disabled={isPending}
               {...register("username")}
             />
             {errors.username && (
@@ -65,6 +62,7 @@ function LoginPage() {
               type="password"
               autoComplete="current-password"
               aria-invalid={!!errors.password}
+              disabled={isPending}
               {...register("password")}
             />
             {errors.password && (
@@ -72,8 +70,34 @@ function LoginPage() {
             )}
           </div>
 
-          <Button type="submit" className="mt-2 w-full">
-            Sign in
+          {isError && (
+            <p className="text-sm text-destructive">Invalid credentials. Please try again.</p>
+          )}
+
+          <Button type="submit" className="mt-2 w-full" disabled={isPending}>
+            {isPending && (
+              <svg
+                className="mr-2 h-4 w-4 animate-spin"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                />
+              </svg>
+            )}
+            {isPending ? "Signing in..." : "Sign in"}
           </Button>
         </form>
       </div>

--- a/src/test/routes/auth-workflow.test.tsx
+++ b/src/test/routes/auth-workflow.test.tsx
@@ -1,8 +1,11 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import axios from "axios";
 
 import { getCredentials, setCredentials } from "#/lib/auth";
 import { renderAppRoute } from "#/test/test-utils";
+
+vi.mock("axios");
 
 const useShowsMock = vi.fn();
 const useTMDBMock = vi.fn();
@@ -42,6 +45,7 @@ function mockHomeQueriesWithEmptyResults() {
 describe("authentication workflow", () => {
   beforeEach(() => {
     mockHomeQueriesWithEmptyResults();
+    vi.mocked(axios.get).mockResolvedValue({ data: {} });
   });
 
   it("redirects guests from protected routes to login", async () => {

--- a/src/test/routes/login.test.tsx
+++ b/src/test/routes/login.test.tsx
@@ -2,20 +2,12 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 
-import { setCredentials } from "#/lib/auth";
+import { useLogin } from "#/hooks/useLogin";
+import { isAuthenticated } from "#/lib/auth";
 import { Route as LoginRoute } from "#/routes/login";
 import { renderRoute } from "#/test/test-utils";
 
-const navigateMock = vi.fn();
-
-vi.mock("@tanstack/react-router", async (importOriginal: <T>() => Promise<T>) => {
-  const actual = await importOriginal<typeof import("@tanstack/react-router")>();
-
-  return {
-    ...actual,
-    useNavigate: () => navigateMock,
-  };
-});
+vi.mock("#/hooks/useLogin");
 
 vi.mock("#/lib/auth", async (importOriginal: <T>() => Promise<T>) => {
   const actual = await importOriginal<typeof import("#/lib/auth")>();
@@ -23,20 +15,25 @@ vi.mock("#/lib/auth", async (importOriginal: <T>() => Promise<T>) => {
   return {
     ...actual,
     isAuthenticated: vi.fn(() => false),
-    setCredentials: vi.fn(),
   };
 });
 
 describe("login page", () => {
   const LoginPage = LoginRoute.options.component!;
+  const loginMock = vi.fn();
+
+  beforeEach(() => {
+    vi.mocked(useLogin).mockReturnValue({
+      login: loginMock,
+      isPending: false,
+      isError: false,
+    });
+  });
 
   it("renders the login form and validates empty fields", async () => {
     const user = userEvent.setup();
 
-    await renderRoute({
-      component: LoginPage,
-      path: "/login",
-    });
+    await renderRoute({ component: LoginPage, path: "/login" });
 
     expect(screen.getByRole("heading", { name: "Welcome back" })).toBeInTheDocument();
 
@@ -44,22 +41,50 @@ describe("login page", () => {
 
     expect(await screen.findByText("Username is required")).toBeInTheDocument();
     expect(screen.getByText("Password is required")).toBeInTheDocument();
-    expect(setCredentials).not.toHaveBeenCalled();
+    expect(loginMock).not.toHaveBeenCalled();
   }, 10000);
 
-  it("submits credentials and navigates home", async () => {
+  it("calls login with the entered credentials on submit", async () => {
     const user = userEvent.setup();
 
-    await renderRoute({
-      component: LoginPage,
-      path: "/login",
-    });
+    await renderRoute({ component: LoginPage, path: "/login" });
 
     await user.type(screen.getByLabelText("Username"), "goledger");
     await user.type(screen.getByLabelText("Password"), "secret");
     await user.click(screen.getByRole("button", { name: "Sign in" }));
 
-    expect(setCredentials).toHaveBeenCalledWith("goledger", "secret");
-    expect(navigateMock).toHaveBeenCalledWith({ to: "/" });
+    expect(loginMock).toHaveBeenCalledWith({ username: "goledger", password: "secret" });
   }, 10000);
+
+  it("shows a spinner and disables the form while pending", async () => {
+    vi.mocked(useLogin).mockReturnValue({
+      login: loginMock,
+      isPending: true,
+      isError: false,
+    });
+
+    await renderRoute({ component: LoginPage, path: "/login" });
+
+    expect(screen.getByRole("button", { name: /signing in/i })).toBeDisabled();
+    expect(screen.getByLabelText("Username")).toBeDisabled();
+    expect(screen.getByLabelText("Password")).toBeDisabled();
+  }, 10000);
+
+  it("shows an error message when login fails", async () => {
+    vi.mocked(useLogin).mockReturnValue({
+      login: loginMock,
+      isPending: false,
+      isError: true,
+    });
+
+    await renderRoute({ component: LoginPage, path: "/login" });
+
+    expect(screen.getByText("Invalid credentials. Please try again.")).toBeInTheDocument();
+  }, 10000);
+
+  it("redirects to home if already authenticated", () => {
+    vi.mocked(isAuthenticated).mockReturnValueOnce(true);
+
+    expect(() => LoginRoute.options.beforeLoad?.({} as never)).toThrow();
+  });
 });


### PR DESCRIPTION
## Summary

- Add `useLogin` hook that validates credentials against `GET /query/getHeader` before storing them. Shows a spinner in the Sign In button and disables the form while pending. Surfaces an inline error on failure without triggering global interceptor toasts.
- Show a spinner inside the watchlist membership checkbox while a toggle mutation is in flight, visible in both add and remove directions. Item is disabled during the mutation to prevent double-clicks.
- Prevent the Edit Show / Delete Show / +Watchlist button row from wrapping on desktop with `md:flex-nowrap`.

## Test plan

- [x] Merge triggers the deploy workflow
- [x] Login with wrong credentials shows inline error and spinner during the request
- [x] Login with correct credentials navigates to home after API responds
- [x] Toggling a watchlist membership shows spinner in the checkbox in both directions
- [x] Edit / Delete / +Watchlist buttons stay on one line on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)
